### PR TITLE
Migrate to AssemblyLine phase 1

### DIFF
--- a/docassemble/MA209AProtectiveOrder/care_and_custody.py
+++ b/docassemble/MA209AProtectiveOrder/care_and_custody.py
@@ -1,0 +1,169 @@
+from docassemble.base.util import DAObject, DAList
+from docassemble.AssemblyLine.al_general import *
+
+__all__ = ['OtherProceeding', 'OtherProceedingList', 'GAL', 'GALList', 'number_to_letter', 'filter_letters']
+
+class OtherProceeding(DAObject):
+  """Currently used to represents a care and custody proceeding."""
+  def init(self, *pargs, **kwargs):
+    super(OtherProceeding, self).init(*pargs, **kwargs)
+    if not hasattr(self, 'children'):
+      self.initializeAttribute('children', ALPeopleList)
+    if not hasattr(self, 'attorneys'):
+      self.initializeAttribute('attorneys', ALPeopleList)
+    if not hasattr(self, 'attorneys_for_children'):
+      self.initializeAttribute('attorneys_for_children', ALPeopleList)
+    if not hasattr(self, 'other_parties'):
+      self.initializeAttribute('other_parties', ALPeopleList)
+    if not hasattr(self, 'gals'):
+      self.initializeAttribute('gals', GALList.using(ask_number=True))
+
+  # We use a property decorator because Docassemble expects this to be an attribute, not a method
+  @property
+  def complete_proceeding(self):
+    """Tells docassemble the list item has been gathered when the variables named below are defined."""
+    # self.user_role # Not asked for adoption cases
+    self.case_status
+    self.children.gathered
+    self.other_parties.gather()
+    if self.is_open:
+      self.atty_for_user
+      if self.atty_for_children:
+        if len(self.children) > 1:
+          self.attorneys_for_children.gather()
+      if self.has_gal:
+        self.gals.gather()
+      else:
+        self.gals.auto_gather=True
+        self.gals.gathered=True
+    return True
+    # We're going to gather this per-attorney instead of
+    # per-case now
+    #if self.case_status == 'pending':
+    #  self.attorneys.gather()
+
+  def child_letters(self):
+    """Return ABC if children lettered A,B,C are part of this case"""
+    return ''.join([child.letter for child in self.children if child.letter])
+
+  def status(self):
+    """Should return the status of the case, suitable to fit on Section 7 of the affidavit disclosing care or custody"""
+    if self.case_status in ['adoption',"adoption-pending", "adoption-closed"]:
+      return 'Adoption'
+    elif hasattr(self, 'custody_awarded') and self.custody_awarded:
+      return "Custody awarded to " + self.person_given_custody + ", " + self.date_of_custody.format("yyyy-MM-dd")
+    elif not self.is_open:
+      return "Closed"
+    elif self.is_open:
+      return 'Pending'
+    else:
+      return self.case_status.title()
+
+  def role(self):
+    """Return the letter representing user's role in the case. If it's an adoption case, don't return a role."""
+    if self.case_status == 'adoption':
+      return ''
+    return self.user_role
+
+  def case_description(self):
+    """Returns a short description of the other case or proceeding meant to display to identify it
+    during list gathering in the course of the interview"""
+    description = ""
+    description += self.case_status.title() + " case in "
+    description += self.court_name
+    if hasattr(self, 'docket_number') and len(self.docket_number.strip()):
+      description += ', case number: ' + self.docket_number
+    description += " (" + str(self.children) + ")"
+    return description
+
+  def role(self):
+    """Return the letter representing user's role in the case. If it's an adoption case, don't return a role."""
+    if self.case_status == 'adoption':
+      return ''
+    return self.user_role
+
+  def __str__(self):
+    return self.case_description()
+
+class OtherProceedingList(DAList):
+  """Represents a list of care and custody proceedings"""
+  def init(self, *pargs, **kwargs):
+    super(OtherProceedingList, self).init(*pargs, **kwargs)
+    self.object_type = OtherProceeding
+    self.complete_attribute = 'complete_proceeding' # triggers the complete_proceeding method of an OtherProceeding
+
+  def includes_adoption(self):
+    """Returns true if any of the listed proceedings was an adoption proceeding."""
+    for case in self.elements:
+      if case.case_status == 'adoption':
+        return True
+  
+  def get_gals(self, intrinsic_name):
+    GALs = GALList(intrinsic_name, auto_gather=False,gathered=True)
+    for case in self:
+      if case.is_open and case.has_gal:
+        for gal in case.gals:
+          if gal.represented_all_children:
+            gal.represented_children = case.children
+          GALs.append(gal, set_instance_name=True)         
+    return GALs
+
+class GAL(ALIndividual):
+  """This object has a helper for printing itself in PDF, as well as a way to merge attributes for duplicates"""
+  def status(self):
+    return str(self) + ' (' + comma_and_list(self.represented_children) + ')'
+  
+  def is_match(self, new_gal):
+    return str(self) == str(new_gal)
+
+  def merge(self, new_gal):
+    self.represented_children = PeopleList(elements=self.represented_children.union(new_gal.represented_children))
+
+class GALList(ALPeopleList):
+  """For storing a list of Guardians ad Litem in Affidavit of Care and Custody"""
+  def init(self, *pargs, **kwargs):
+    super(GALList, self).init(*pargs, **kwargs)
+    self.object_type = GAL
+
+  def append(self, new_item, set_instance_name=False):
+    """Only append if this GAL has a unique name"""
+    match = False
+    for item in self:
+      if item.is_match(new_item):
+        match = True
+        # Merge list of children represented if same name
+        item.merge(new_item)
+    if not match:
+      return super().append(new_item, set_instance_name=set_instance_name)    
+    return None
+  
+
+def number_to_letter(n):
+  """Returns a capital letter representing ordinal position. E.g., 1=A, 2=B, etc. Appends letters
+  once you reach 26 in a way compatible with Excel/Google Sheets column naming conventions. 27=AA, 28=AB...
+  """
+  string = ""
+  if n is None:
+    n = 0
+  while n > 0:
+    n, remainder = divmod(n - 1, 26)
+    string = chr(65 + remainder) + string
+  return string
+
+def filter_letters(letter_strings):
+  """Used to take a list of letters like ["A","ABC","AB"] and filter out any duplicate letters."""
+  # There is probably a cute one liner, but this is easy to follow and
+  # probably same speed
+  unique_letters = set()
+  if isinstance(letter_strings, str):
+    letter_strings = [letter_strings]
+  for string in letter_strings:
+    if string: # Catch possible None values
+      for letter in string:
+        unique_letters.add(letter)
+  try:
+    retval = ''.join(sorted(unique_letters))
+  except:
+    reval = ''
+  return retval
+  

--- a/docassemble/MA209AProtectiveOrder/data/questions/209A-defendant-child-support.yml
+++ b/docassemble/MA209AProtectiveOrder/data/questions/209A-defendant-child-support.yml
@@ -4,7 +4,7 @@ question: |
 subquestion: |
   Enter the appropriate court division.
 fields:
-  - 'Court Division': courts[0]
+  - 'Court Division': trial_court
 ---
 question: |
   Your Insurance Expenses
@@ -135,7 +135,7 @@ attachment:
       - "child2_name_full": ${ str(children[2-1]) }
       - "child4_name_full": ${ str(children[4-1]) }
       - "user_name_full__2": ${ str(users[0]) }
-      - "court_division": ${ courts[0] }
+      - "court_division": ${ trial_court }
       - "is_father": ${ is_father }
       - "is_mother": ${ is_mother }
       - "user_work_job_title": ${ users[0].work_job_title }
@@ -171,7 +171,7 @@ subquestion: |
 id: interview_order_A_defendant_s_child_support_affidavit_ready_for_upload0004
 code: |
   # This is a placeholder to control logic flow in this interview
-  # It was generated from interview_generator.py as an 'interview order' type question.  basic_questions_intro_screen 
+  # It was generated from interview_generator.py as an 'interview order' type question.  al_intro_screen 
   A_defendant_s_child_support_affidavit_ready_for_upload0004_intro
   # Set the preferred/allowed courts for this interview
   # preferred_court = interview_metadata["A_defendant_s_child_support_affidavit_ready_for_upload0004"]["preferred court"]
@@ -181,7 +181,7 @@ code: |
   str(plaintiffs[0])
   str(users[0])
   str(children[1-1])
-  courts[0]
+  trial_court
   is_father
   users[0].work_job_title
   if users[0].gross_income_weekly_or_monthly is 'weekly':
@@ -265,7 +265,7 @@ attachment:
       - "child2_name_full": ${ str(children[2-1]) }
       - "child4_name_full": ${ str(children[4-1]) }
       - "user_name_full__2": ${ str(users[0]) }
-      - "court_division": ${ courts[0] }
+      - "court_division": ${ trial_court }
       - "is_father": ${ is_father }
       - "is_mother": ${ is_mother }
       - "user_work_job_title": ${ users[0].work_job_title }

--- a/docassemble/MA209AProtectiveOrder/data/questions/209A_affidavit.yml
+++ b/docassemble/MA209AProtectiveOrder/data/questions/209A_affidavit.yml
@@ -57,12 +57,9 @@ data:
     field_type: text
     maxlength: 25
 ---
-include:
-  - docassemble.MAVirtualCourt:basic-questions.yml
----
 id: complaint_209A_Affidavit
 code: |
-  basic_questions_intro_screen 
+  al_intro_screen 
   complaint_209A_Affidavit_intro
   complaint_209A_Affidavit_intro_2
   complaint_209A_Affidavit_intro_3

--- a/docassemble/MA209AProtectiveOrder/data/questions/209A_affidavit_disclosing_care_or_custody_proceedings.yml
+++ b/docassemble/MA209AProtectiveOrder/data/questions/209A_affidavit_disclosing_care_or_custody_proceedings.yml
@@ -1,4 +1,7 @@
 ---
+modules:
+  - .care_and_custody
+---
 objects:
   - other_care_custody_proceedings: OtherProceedingList
   - signing_attorney: ALIndividual

--- a/docassemble/MA209AProtectiveOrder/data/questions/209A_affidavit_disclosing_care_or_custody_proceedings.yml
+++ b/docassemble/MA209AProtectiveOrder/data/questions/209A_affidavit_disclosing_care_or_custody_proceedings.yml
@@ -1,7 +1,7 @@
 ---
 objects:
   - other_care_custody_proceedings: OtherProceedingList
-  - signing_attorney: VCIndividual
+  - signing_attorney: ALIndividual
   # - children: PeopleList.using(complete_attribute='child_complete')
   - others_in_proceedings: PeopleList.using(auto_gather=False)
   - attorneys_for_children: PeopleList.using(auto_gather=False)
@@ -12,7 +12,7 @@ id: interview_order_A_affidavit_disclosing_care_or_custody_proceedings0009
 code: |
   # This is a placeholder to control logic flow in this interview
   # It was generated from interview_generator.py as an 'interview order' type question.  
-  basic_questions_intro_screen 
+  al_intro_screen 
   # A_affidavit_disclosing_care_or_custody_proceedings0009_intro # enable for 
 
   defendants.there_are_any = True  
@@ -77,7 +77,7 @@ code: |
 #   initialize_attorney_lists = True
 ---
 code: |
-  DCF = VCIndividual("DCF")
+  DCF = ALIndividual("DCF")
   DCF.address = DAEmpty()
   DCF.address_for_form = DAEmpty()
   DCF.name.first = "Department of Children and Families"
@@ -267,6 +267,9 @@ code: |
 code: |
   case_name = str(plaintiffs) + ' v ' + str(defendants)
 ---
+sets:
+  - other_parties[i].name.first
+  - other_parties[i].name.last
 id: name of other party
 question: |
   What is the name of the person on the other side of this case?
@@ -277,28 +280,19 @@ subquestion: |
   If you need to list more than one person on this form, you can click
   "Add another".
 fields:
-  - First name: other_parties[i].name.first
-  - Middle: other_parties[i].name.middle
-    required: False
-  - Last: other_parties[i].name.last
-    required: False
-  - Suffix: other_parties[i].name.suffix
-    code: |
-      name_suffix()
-    required: False      
-list collect: True      
+  - code: other_parties[i].name_fields()
 ---
 code: |
-  if 'District' in courts[0].name:
-    courts[0].division_district_court = courts[0].division
-  elif 'Superior' in courts[0].name:
-    courts[0].division_superior_court = courts[0].division
-  elif 'Juvenile' in courts[0].name:
-    courts[0].division_juvenile_court = courts[0].division
-  elif 'Probate' in courts[0].name:
-    courts[0].division_family_court = courts[0].division
-  elif 'Municipal' in courts[0].name: 
-    courts[0].division_bmc = courts[0].division
+  if 'District' in trial_court.name:
+    trial_court.division_district_court = trial_court.division
+  elif 'Superior' in trial_court.name:
+    trial_court.division_superior_court = trial_court.division
+  elif 'Juvenile' in trial_court.name:
+    trial_court.division_juvenile_court = trial_court.division
+  elif 'Probate' in trial_court.name:
+    trial_court.division_family_court = trial_court.division
+  elif 'Municipal' in trial_court.name: 
+    trial_court.division_bmc = trial_court.division
   fill_in_court_name = True
 ---
 code: |
@@ -557,7 +551,7 @@ fields:
     hide if: other_care_custody_proceedings[i].non_ma_court
     datatype: combobox
     code: |
-      sorted((set([str(y) for y in macourts.filter_courts(["District Court","Boston Municipal Court", "Probate and Family Court", "Superior Court", "Juvenile Court"])])))
+      sorted((set([str(y) for y in all_courts.filter_courts(["District Court","Boston Municipal Court", "Probate and Family Court", "Superior Court", "Juvenile Court"])])))
   - Docket number or case number: other_care_custody_proceedings[i].docket_number
     required: False
   - Which children were involved in this case?: other_care_custody_proceedings[i].children
@@ -1034,11 +1028,11 @@ attachment:
       - "child3_address_city_state_zip": ${ children_of_both.item(2).address.line_two() }
       - "user_address_on_one_line__2": ${ users[0].address.on_one_line(include_unit=True) }
       - "case_name": ${ case_name }
-      - "court_division_bmc": ${ showifdef('courts[0].division_bmc') }
-      - "court_division_district_court": ${ showifdef('courts[0].division_district_court') }
-      - "court_division_juvenile_court": ${ showifdef('courts[0].division_juvenile_court') }
-      - "court_division_family_court": ${ showifdef('courts[0].division_family_court') }
-      - "court_division_superior_court": ${ showifdef('courts[0].division_superior_court') }
+      - "court_division_bmc": ${ showifdef('trial_court.division_bmc') }
+      - "court_division_district_court": ${ showifdef('trial_court.division_district_court') }
+      - "court_division_juvenile_court": ${ showifdef('trial_court.division_juvenile_court') }
+      - "court_division_family_court": ${ showifdef('trial_court.division_family_court') }
+      - "court_division_superior_court": ${ showifdef('trial_court.division_superior_court') }
       - "child1_name_last_first": ${ children_of_both.item(0).name.lastfirst() }
       - "child2_name_last_first": ${ children_of_both.item(1).name.lastfirst() }
       - "child3_name_last_first": ${ children_of_both.item(2).name.lastfirst() }
@@ -1146,11 +1140,11 @@ attachment:
       - "child3_address_city_state_zip": ${ children_of_both.item(2).address.line_two() }
       - "user_address_on_one_line__2": ${ users[0].address.on_one_line(include_unit=True) }
       - "case_name": ${ case_name }
-      - "court_division_bmc": ${ showifdef('courts[0].division_bmc') }
-      - "court_division_district_court": ${ showifdef('courts[0].division_district_court') }
-      - "court_division_juvenile_court": ${ showifdef('courts[0].division_juvenile_court') }
-      - "court_division_family_court": ${ showifdef('courts[0].division_family_court') }
-      - "court_division_superior_court": ${ showifdef('courts[0].division_superior_court') }
+      - "court_division_bmc": ${ showifdef('trial_court.division_bmc') }
+      - "court_division_district_court": ${ showifdef('trial_court.division_district_court') }
+      - "court_division_juvenile_court": ${ showifdef('trial_court.division_juvenile_court') }
+      - "court_division_family_court": ${ showifdef('trial_court.division_family_court') }
+      - "court_division_superior_court": ${ showifdef('trial_court.division_superior_court') }
       - "child1_name_last_first": ${ children_of_both.item(0).name.lastfirst() }
       - "child2_name_last_first": ${ children_of_both.item(1).name.lastfirst() }
       - "child3_name_last_first": ${ children_of_both.item(2).name.lastfirst() }

--- a/docassemble/MA209AProtectiveOrder/data/questions/209A_affidavit_disclosing_care_or_custody_proceedings.yml
+++ b/docassemble/MA209AProtectiveOrder/data/questions/209A_affidavit_disclosing_care_or_custody_proceedings.yml
@@ -35,10 +35,10 @@ code: |
   # initialize_attorney_lists
   other_care_custody_proceedings.gather()
   for case in other_care_custody_proceedings:
-    for person in case.other_parties:
-      person.address.geolocate(person.address_for_form)
-      if not person.address.geolocated:
-        person.address = DAEmpty()
+    # for person in case.other_parties:
+    #  person.address.geolocate(person.address_for_form)
+    #  if not person.address.geolocated:
+    #    person.address = DAEmpty()
     if case.is_open:
       case.atty_for_user
       if case.atty_for_children and len(case.children) > 1:
@@ -647,6 +647,8 @@ code: |
 #   was a party to this case? For example, a grandparent or other parent of the child.
 # yesno: other_care_custody_proceedings[i].other_parties.there_are_any
 ---
+sets:
+  - other_care_custody_proceedings[i].other_parties[j].address.address
 id: other parties in case
 question: |
   Who else was involved in this case?
@@ -667,9 +669,8 @@ fields:
       - DCF
       - other_parties[0]
   - Name: other_care_custody_proceedings[i].other_parties[j].name.first
-  - Address: other_care_custody_proceedings[i].other_parties[j].address_for_form
-    address autocomplete: True
-    required: False
+  - code: |
+      other_care_custody_proceedings[i].other_parties[j].address_fields(default_state="MA")
 # validation code: |
   # other_care_custody_proceedings[i].other_parties[j].address.geolocate(other_care_custody_proceedings[i].other_parties[j].address_for_form)
   # if not other_care_custody_proceedings[i].other_parties[j].address.geolocated:

--- a/docassemble/MA209AProtectiveOrder/data/questions/209A_attach_exhibits.yml
+++ b/docassemble/MA209AProtectiveOrder/data/questions/209A_attach_exhibits.yml
@@ -1,6 +1,3 @@
-#---
-#include: 
-#  - docassemble.MAVirtualCourt:basic-questions.yml
 ---
 objects:
   - exhibits: DAFileList.using(auto_gather=False, gathered=True)

--- a/docassemble/MA209AProtectiveOrder/data/questions/209A_child-support.yml
+++ b/docassemble/MA209AProtectiveOrder/data/questions/209A_child-support.yml
@@ -306,7 +306,7 @@ id: interview_order_Plaintiff_Affidavit_in_support_of_request_for_child_support_
 code: |
   # This is a placeholder to control logic flow in this interview
   # It was generated from interview_generator.py as an 'interview order' type question.  
-  basic_questions_intro_screen 
+  al_intro_screen 
   Plaintiff_Affidavit_in_support_of_request_for_child_support_order0008_intro
 
   # users[0].states_above_true

--- a/docassemble/MA209AProtectiveOrder/data/questions/209A_defendant-information.yml
+++ b/docassemble/MA209AProtectiveOrder/data/questions/209A_defendant-information.yml
@@ -485,7 +485,7 @@ id: interview_order_defendantinformation209A0008
 code: |
   # This is a placeholder to control logic flow in this interview
   # It was generated from interview_generator.py as an 'interview order' type question.
-  basic_questions_intro_screen 
+  al_intro_screen 
   defendantinformation209A0008_intro
   # Set the preferred/allowed courts for this interview
   # preferred_court = interview_metadata["defendantinformation209A0008"]["preferred court"]

--- a/docassemble/MA209AProtectiveOrder/data/questions/209A_motion-for-impoundment.yml
+++ b/docassemble/MA209AProtectiveOrder/data/questions/209A_motion-for-impoundment.yml
@@ -175,7 +175,7 @@ id: interview_order_a_258e_motion_for_impoundment0019
 code: |
   # This is a placeholder to control logic flow in this interview
   # It was generated from interview_generator.py as an 'interview order' type question.
-  basic_questions_intro_screen
+  al_intro_screen
   # If the user needs to fill out the form
   #if a_258e_motion_for_impoundment0019_intro:
   # Set the preferred/allowed courts for this interview

--- a/docassemble/MA209AProtectiveOrder/data/questions/209A_package_skip_basic_facts.yml
+++ b/docassemble/MA209AProtectiveOrder/data/questions/209A_package_skip_basic_facts.yml
@@ -80,7 +80,7 @@ include:
 sets: skip_intro
 scan for variables: False
 code: |
-  basic_questions_intro_screen  = True
+  al_intro_screen  = True
   main_209A_package_intro = True
   acknowledged_information_use = True
   user_saw_what_to_expect = True
@@ -367,7 +367,7 @@ code: |
   skip_orders = True
 ---
 code: |
-  courts[0] = macourts[26] # Should be BMC East Boston Division
+  trial_court = all_courts[26] # Should be BMC East Boston Division
   docket_numbers.auto_gather = False  
   docket_numbers[0] = '20-CV-1234'
   docket_numbers.gathered=True

--- a/docassemble/MA209AProtectiveOrder/data/questions/209A_page_1.yml
+++ b/docassemble/MA209AProtectiveOrder/data/questions/209A_page_1.yml
@@ -74,19 +74,14 @@ question: |
 fields:
   - code: |
       other_parties[0].name_fields()
-  - Gender: other_parties[0].gender
-    choices:
-      - Female: female
-      - Male: male
-      - Non-binary: non-binary
-      - Prefer not to say: prefer-not-to-say
-      - Prefer to write in a different gender: self-described
-    help: |
-      If you do not select "Male" or "Female", both checkboxes will be empty on the form. The police use your answer to help them identify the person who is abusing you and enforce your restraining order.  
-  - Gender: other_parties[0].gender
-    show if:
-      variable: other_parties[0].gender
-      is: "self-described"
+  - code: |
+      other_parties[0].gender_fields(show_help=True)
+---
+template: other_parties[0].gender_help_text
+content: |
+  If you do not select "Male" or "Female", both checkboxes will be empty on the
+  form. The police use your answer to help them identify the person who is 
+  abusing you and enforce your restraining order.
 ---
 id: what to expect
 question: |
@@ -575,6 +570,9 @@ fields:
   - License to carry: defendant_has_guns['license']
     datatype: yesnomaybe
 ---
+depends on:
+  - defendant_has_guns
+  - defendant_weapons_description
 code: |
   defendant_weapons = comma_list(defendant_has_guns.true_values()) + space('defendant_weapons_description', prefix=' - ')
   defendant_weapons_safe_for_pdf = defendant_weapons + (" (see Addendum)" if len(defendant_weapons) > 40 else '')
@@ -1101,7 +1099,9 @@ buttons:
   - Restart: restart
 attachment code: complaint_209A_labeled_page10003_attachment
 ---
-need: complaint_209A_labeled_page10003
+need: 
+  - complaint_209A_labeled_page10003
+  - defendant_weapons_safe_for_pdf
 attachment:
     variable name: complaint_209A_labeled_page10003_attachment
     skip undefined: True

--- a/docassemble/MA209AProtectiveOrder/data/questions/209A_page_1.yml
+++ b/docassemble/MA209AProtectiveOrder/data/questions/209A_page_1.yml
@@ -68,6 +68,7 @@ fields:
 sets:
   - other_parties[0].name.first
   - other_parties[0].name.last
+  - other_parties[0].gender
 id: name of abuser
 question: |
   What is the name of the person who is abusing you?  

--- a/docassemble/MA209AProtectiveOrder/data/questions/209A_page_1.yml
+++ b/docassemble/MA209AProtectiveOrder/data/questions/209A_page_1.yml
@@ -65,18 +65,15 @@ fields:
       - I need the order to protect me and my children.: me and children
       - I am helping someone else ask for this order.: someone else
 ---
+sets:
+  - other_parties[0].name.first
+  - other_parties[0].name.last
 id: name of abuser
 question: |
   What is the name of the person who is abusing you?  
 fields:
-  - First name: other_parties[0].name.first
-  - Middle name: other_parties[0].name.middle
-    required: False
-  - Last name: other_parties[0].name.last
-  - Suffix: other_parties[0].name.suffix
-    required: False
-    code: |
-      name_suffix()
+  - code: |
+      other_parties[0].name_fields()
   - Gender: other_parties[0].gender
     choices:
       - Female: female
@@ -90,7 +87,6 @@ fields:
     show if:
       variable: other_parties[0].gender
       is: "self-described"
-
 ---
 id: what to expect
 question: |
@@ -213,9 +209,6 @@ subquestion: |
 buttons:
   - Exit: exit
   - Restart: restart
----
-include:
-  - docassemble.MAVirtualCourt:basic-questions.yml
 ---
 id: helper relationship
 question: |
@@ -888,7 +881,7 @@ id: complaint_209A_labeled_page10003
 code: |
   # allowed_courts = interview_metadata['complaint_209A_labeled_page10003']['allowed courts']
   # preferred_court = interview_metadata['complaint_209A_labeled_page10003']['preferred court']
-  # basic_questions_intro_screen 
+  # al_intro_screen 
   # user_saw_what_to_expect
   # users[0].name.first
   # plaintiff_is_major_yes # Ask for age
@@ -1047,11 +1040,11 @@ attachment:
       - "user_name_full": ${ str(users[0]) }
       - "defendant": ${ str(other_parties[0]) }
       - "signature_date": ${ signature_date.format("M/d/yyyy") }
-      - "municipal_court": ${ courts[0].department == "Boston Municipal Court" }
-      - "district_court": ${ courts[0].department == "District Court" }
-      - "probate_court": ${ courts[0].department == "Probate and Family Court" }
-      - "superior_court": ${ courts[0].department == "Superior Court" }
-      - "court_name_short": ${ courts[0].division }
+      - "municipal_court": ${ trial_court.department == "Boston Municipal Court" }
+      - "district_court": ${ trial_court.department == "District Court" }
+      - "probate_court": ${ trial_court.department == "Probate and Family Court" }
+      - "superior_court": ${ trial_court.department == "Superior Court" }
+      - "court_name_short": ${ trial_court.division }
       - "defendant_alias": ${ other_parties[0].name_other if defendant_has_alias else '' }
       - "defendant_weapons_description": ${ defendant_weapons_safe_for_pdf  }
       - "defendant_gender_male": ${ other_parties[0].gender_male }
@@ -1121,11 +1114,11 @@ attachment:
       - "user_name_full": ${ str(users[0]) }
       - "defendant": ${ str(other_parties[0]) }
       - "signature_date": ${ signature_date.format("M/d/yyyy") }
-      - "municipal_court": ${ courts[0].department == "Boston Municipal Court" }
-      - "district_court": ${ courts[0].department == "District Court" }
-      - "probate_court": ${ courts[0].department == "Probate and Family Court" }
-      - "superior_court": ${ courts[0].department == "Superior Court" }
-      - "court_name_short": ${ courts[0].division }
+      - "municipal_court": ${ trial_court.department == "Boston Municipal Court" }
+      - "district_court": ${ trial_court.department == "District Court" }
+      - "probate_court": ${ trial_court.department == "Probate and Family Court" }
+      - "superior_court": ${ trial_court.department == "Superior Court" }
+      - "court_name_short": ${ trial_court.division }
       - "defendant_alias": ${ other_parties[0].name_other if defendant_has_alias else '' }
       - "defendant_weapons_description": ${ defendant_weapons_safe_for_pdf  }
       - "defendant_gender_male": ${ other_parties[0].gender_male }

--- a/docassemble/MA209AProtectiveOrder/data/questions/209A_page_2.yml
+++ b/docassemble/MA209AProtectiveOrder/data/questions/209A_page_2.yml
@@ -22,7 +22,7 @@ code: |
 
   interview_id = "A_complaint_for_protection_from_abuse_probation_copy0005"
 
-  # basic_questions_intro_screen 
+  # al_intro_screen 
   # A_complaint_for_protection_from_abuse_probation_copy0005_intro  # Need a way to skip intro to every form?
 
   #######
@@ -302,6 +302,9 @@ help:
 
     At the 10 day hearing, ${other_parties.familiar()} can try to convince the judge to change the order. 
 ---
+sets: 
+  - children[i].name.first
+  - children[i].name.last
 comment: |
   Changed code to list only first names of children in question, but then choices for children_of_both in q. id: custody_children became their full names instead of only first names even after I added '.familiar()' to the end.
 # `ordinal()` says 'first', even if there's only one :(
@@ -328,14 +331,8 @@ subquestion: |
   % endif
  
 fields:
-  - First Name: children[i].name.first
-  - Middle Name: children[i].name.middle
-    required: False
-  - Last Name: children[i].name.last
-  - Suffix: children[i].name.suffix
-    required: False
-    code: |
-      name_suffix()
+  - code: |
+      children[i].name_fields()
   - Birthdate: children[i].birthdate
     datatype: BirthDate
     min: ${ today().minus(years=18) }
@@ -352,6 +349,51 @@ validation code: |
   if children[i].birthdate < today().minus(years=18):
     validation_error("The court asks only for children under 18", field="children[i].birthdate")
 ---
+sets: 
+  - children[0].name.first
+  - children[0].name.last
+comment: |
+  Changed code to list only first names of children in question, but then choices for children_of_both in q. id: custody_children became their full names instead of only first names even after I added '.familiar()' to the end.
+# `ordinal()` says 'first', even if there's only one :(
+id: children user is parent of
+question: |
+  % if children.target_number == 1:
+  Your child
+  % else:
+  Your children
+  % endif
+subquestion: |  
+  % if children.target_number == 1:
+  Tell us about your child
+  % else:
+  Tell us about your oldest child first.
+  % endif
+     
+  % if children_cares_for.target_number >= 1:
+  For now, just name your own ${ children.as_noun()}.
+  % endif 
+fields:
+  - code: |
+      children[0].name_fields()
+  - Birthdate: children[0].birthdate
+    datatype: BirthDate
+    min: ${ today().minus(years=18) }
+    max: ${ today() }
+    validation messages:
+      min: |
+        The court asks only for children under 18.
+  - Is ${other_parties.familiar()} this child's other parent?: children[0].defendant_is_parent
+    datatype: yesnoradio
+    show if:
+      code: |
+        defendant_and_plaintiff_are_parents_of_child # means parents of any children
+validation code: |
+  if children[0].birthdate < today().minus(years=18):
+    validation_error("The court asks only for children under 18", field="children[0].birthdate")
+---
+sets:
+  - children_cares_for[i].name.first
+  - children_cares_for[i].name.last
 id: non_parent_children
 question: |
   % if ( children_cares_for.target_number == 1 ):
@@ -369,16 +411,9 @@ subquestion: |
   You have already told us
   about ${comma_and_list(children_cares_for.complete_elements())}.
   % endif
-  
 fields:
-  - First Name: children_cares_for[i].name.first
-  - Middle Name: children_cares_for[i].name.middle
-    required: False
-  - Last Name: children_cares_for[i].name.last
-  - Suffix: children_cares_for[i].name.suffix
-    required: False
-    code: |
-      name_suffix()
+  - code: |
+      children_cares_for[i].name_fields()
   - Birthdate: children_cares_for[i].birthdate
     datatype: BirthDate
     min: ${ today().minus(years=18) }
@@ -460,25 +495,23 @@ yesno: schools_to_stay_away_from.there_are_any
 ---
 # For listing for each child (if we choose to do that), see
 # 209A_affidavit_disclosing_care_or_custody_proceedings.yml on its branch
+sets:
+  - schools_to_stay_away_from[i].address.address
+  - schools_to_stay_away_from[i].address.city
 id: schools_and_daycares
 question:
   What are the schools or daycare centers you need the court to order ${other_parties.familiar()} to stay away from?
-list collect: True
-minimum number: 1
+subquestion: |
+  We will ask about each school one at a time.
 fields:
   - School or daycare name: schools_to_stay_away_from[i].name.text
-  - Street address: schools_to_stay_away_from[i].address.address
-    address autocomplete: True
-  # needed?
-  - Unit: schools_to_stay_away_from[i].address.unit
-    required: False
-  - City: schools_to_stay_away_from[i].address.city
-  - State: schools_to_stay_away_from[i].address.state
-    code: |
-      states_list()
-    default: MA      
-  - Zip: schools_to_stay_away_from[i].address.zip
-    required: False
+  - code: |
+      schools_to_stay_away_from[i].address_fields()
+---
+id: schools and daycares has another
+question: |
+  Is there another school or daycare you need ${ other_parties.familiar() } to stay away from?
+yesno: schools_to_stay_away_from.there_is_another
 # ---
 # id: wants_to_request_visitation_details
 # question: |
@@ -689,22 +722,22 @@ yesno: majors_needing_support.there_are_any
 code: |
   need_help_for_majors = majors_needing_support.there_are_any
 ---
+sets:
+  - majors_needing_support[i].name.first
+  - majors_needing_support[i].name.last
 id: non_minors_needing_child_support
 question: |
   Who are your children between 18 and 22? 
 subquestion: |
-  Include any children who are 22.
-
-  Click "${word("Add another")}" to add more.
-list collect: True
+  Include any children who are 22. We will ask about them one at a time.
 fields:
-  - First Name: majors_needing_support[i].name.first
-  - Middle Name: majors_needing_support[i].name.middle
-    required: False
-  - Last Name: majors_needing_support[i].name.last
-  - Suffix: majors_needing_support[i].name.suffix
-    required: False
-    code: name_suffix()
+  - code: |
+      majors_needing_support[i].name_fields()
+---
+id: another major needing support
+question: |
+  Do you have any other children between 18 and 22?
+yesno: majors_needing_support.there_is_another
 ---
 id: do you already have a child support order
 question: |

--- a/docassemble/MA209AProtectiveOrder/data/questions/209A_page_2.yml
+++ b/docassemble/MA209AProtectiveOrder/data/questions/209A_page_2.yml
@@ -109,7 +109,8 @@ code: |
     child_support_safety
     wants_child_support_yes
     if need_help_for_majors:
-      majors_needing_support[0].name.first
+      majors_needing_support.gather()
+      # majors_needing_support[0].name.first
 
   # REMOVED in stitchup -- ask these later
   # have_had_custody_cases

--- a/docassemble/MA209AProtectiveOrder/data/questions/209A_page_2.yml
+++ b/docassemble/MA209AProtectiveOrder/data/questions/209A_page_2.yml
@@ -216,7 +216,7 @@ objects:
   - children_cares_for: PeopleList.using(ask_number=True)
   - wants_custody_of: PeopleList
   - wants_no_contact_for: PeopleList
-  - schools_to_stay_away_from: DAList.using(object_type=Person)
+  - schools_to_stay_away_from: DAList.using(object_type=ALIndividual)
   - majors_needing_support: PeopleList
 ---
 comment: |
@@ -504,7 +504,7 @@ question:
 subquestion: |
   We will ask about each school one at a time.
 fields:
-  - School or daycare name: schools_to_stay_away_from[i].name.text
+  - School or daycare name: schools_to_stay_away_from[i].name.first
   - code: |
       schools_to_stay_away_from[i].address_fields()
 ---

--- a/docassemble/MA209AProtectiveOrder/data/questions/209A_plaintiff-confidential.yml
+++ b/docassemble/MA209AProtectiveOrder/data/questions/209A_plaintiff-confidential.yml
@@ -55,24 +55,28 @@ subquestion: |
   Most shelters have a P.O. Box you can use if the court needs to contact you or mail you anything.
 continue button field: domestic_violence_shelter_warning
 ---
+sets:
+  - users[0].previous_addresses[i].address
+  - users[0].previous_addresses[i].city
 id: fled from addresses
 question: |
   Former addresses
 subquestion: |
   Provide any address you recently left to avoid abuse from ${other_parties.familiar()}.
 
-  If you need to add more than one address, click "${word("Add another")}." 
+  Tell us about each address one at a time.
 fields: 
-  - Address: users[0].previous_addresses[i].address
-    address autocomplete: True
-  - Unit:     users[0].previous_addresses[i].unit
-    required: False
-  - City: users[0].previous_addresses[i].city
-  - State: users[0].previous_addresses[i].state
-    code: |
-      states_list()
-    default: "MA"    
-list collect: True    
+  - code: |
+      users[0].previous_addresses[i].address_fields(default_state="MA")
+---
+id: fled from addresses more
+question: |
+  Former addresses
+subquestion: |
+  So far you have told us about ${ users[0].previous_addresses.complete_elements() }.
+  
+  Is there any other previous address you need to tell the court about?
+yesno: users[0].previous_addresses.there_is_another
 ---
 # question: |
 #  When were you born?
@@ -341,6 +345,7 @@ code: |
   str(users[0])
   if lives_in_domestic_violence_shelter:
     domestic_violence_shelter_warning
+  users[0].other_addresses.there_are_any # ask this first to get the right address screen
   users[0].address.address
   users[0].other_addresses.gather()
   users[0].mobile_number

--- a/docassemble/MA209AProtectiveOrder/data/questions/209A_plaintiff-confidential.yml
+++ b/docassemble/MA209AProtectiveOrder/data/questions/209A_plaintiff-confidential.yml
@@ -192,20 +192,14 @@ subquestion: |
   The court keeps your address on the Plaintiff Confidential Information form, separate from the rest of your file. 
   % endif 
 fields:
-  - Street address: users[0].address.address
-    address autocomplete: True
-  - Unit: users[0].address.unit
-    required: False
-  - City: users[0].address.city
-  - State: users[0].address.state
-    code: |
-      states_list()
-    default: MA      
-  - Zip: users[0].address.zip
-    required: False
+  - code: |
+      users[0].address_fields(default_state="MA")
   - I live at more than one address: users[0].other_addresses.there_are_any
     datatype: yesno
 ---
+sets:
+  - users[0].other_addresses[i].address
+  - users[0].other_addresses[i].city
 id: other address where plaintiff lives
 question: |
   Tell us about the ${ordinal(i)} other address where you live
@@ -215,17 +209,8 @@ subquestion: |
   as well as ${users[0].other_addresses.complete_elements()}
   % endif
 fields:
-  - Street address: users[0].other_addresses[i].address
-    address autocomplete: True
-  - Unit: users[0].other_addresses[i].unit
-    required: False
-  - City: users[0].other_addresses[i].city
-  - State: users[0].other_addresses[i].state
-    code: |
-      states_list()
-    default: MA      
-  - Zip: users[0].other_addresses[i].zip
-    required: False
+  - code: |
+      users[0].other_addresses[i].address_fields(default_state="MA")
 ---
 id: has another other address
 question: |
@@ -320,9 +305,6 @@ attachment:
       - "plaintiff_preferred_language": ${user_preferred_language if user_needs_interpreter else ''} 
       - "plaintiff_signature": ${ users[0].signature }
 ---
-include:
-  - docassemble.MAVirtualCourt:basic-questions.yml
----
 id: plaintiff confidential intro
 comment: |
   This question is used to introduce your interview. Please customize
@@ -353,7 +335,7 @@ help:
 id: interview_order_A_Plaintiff_Confidential_Information0011
 code: |
   # This is a placeholder to control logic flow in this interview
-  # It was generated from interview_generator.py as an 'interview order' type question.  basic_questions_intro_screen 
+  # It was generated from interview_generator.py as an 'interview order' type question.  al_intro_screen 
   A_Plaintiff_Confidential_Information0011_intro
 
   str(users[0])

--- a/docassemble/MA209AProtectiveOrder/data/questions/209A_review.yml
+++ b/docassemble/MA209AProtectiveOrder/data/questions/209A_review.yml
@@ -613,9 +613,9 @@ event: section_court
 question: |
   Your court
 review:
-  - Edit court: courts[0]
+  - Edit court: trial_court
     button: |
-      ${courts[0]}
+      ${trial_court}
 ---
 ###################################### Signature
 id: signature

--- a/docassemble/MA209AProtectiveOrder/data/questions/209a_package.yml
+++ b/docassemble/MA209AProtectiveOrder/data/questions/209a_package.yml
@@ -1,6 +1,7 @@
 ---
 include:
- - docassemble.MAVirtualCourt:basic-questions.yml
+ - docassemble.AssemblyLine:al_package.yml
+ - docassemble.MassAccess:massaccess.yml
  - 209A_page_1.yml
  - 209A_page_2.yml
  - 209A_child-support.yml
@@ -21,8 +22,8 @@ metadata:
   back button label: Undo
 ---
 modules:
-  - docassemble.AssemblyLineToolbox.misc
-  - docassemble.AssemblyLineToolbox.ThreePartsDate # Not strictly necessary as long it's installed somewhere on the server
+  - docassemble.ALToolbox.misc
+  - docassemble.ALToolbox.ThreePartsDate # Not strictly necessary as long it's installed somewhere on the server
 ---
 features:
   navigation: True
@@ -56,7 +57,7 @@ code: |
   set_interview_defaults # Set some things that are true on any 209A
   
   ##################### Intro screen
-  basic_questions_intro_screen
+  al_intro_screen
   main_209A_package_intro
   nav.set_section('section_basic')  
   who_protecting_screener # We don't use this yet?  
@@ -222,24 +223,16 @@ code: |
   final_attachment_collection.finished
   download_screen
 ---
-id: dev hud etc
-code: |
-  # For info at the top of the screen on dev and test servers
-  package_version_number = str( docassemble.MAVirtualCourt.__version__ )
----
+sets:
+  - users[0].name.first
+  - users[0].name.last
 if: |
   who_protecting_screener == "someone else"
 question: |
   What is the name of the person who needs the order?
 fields:
-  - First Name: users[0].name.first
-  - Middle Name: users[0].name.middle
-    required: False
-  - Last Name: users[0].name.last
-  - Suffix: users[0].name.suffix
-    code: |
-      name_suffix()
-    required: False  
+  - code: |
+      users[0].name_fields()
 ---
 id: explain first person questions
 question: |
@@ -278,15 +271,15 @@ question: |
 subquestion: |
   1. Look over the forms below.
   1. If they look correct, download them or email them to yourself.
-  1. You still need to deliver them to the ${courts[0]}, when you are ready.
-  4. Call the ${courts[0]}'s clerk: <a href="tel:${courts[0].phone}">${courts[0].phone}</a> to find out how they want you to send your forms to them.
+  1. You still need to deliver them to the ${trial_court}, when you are ready.
+  4. Call the ${trial_court}'s clerk: <a href="tel:${trial_court.phone}">${trial_court.phone}</a> to find out how they want you to send your forms to them.
   % if court_closed_today:
   4. The court is closed today. If you need help to file these forms now, call your local police station.
   % elif after_hours:
   5. The court is only open between 8:30 AM and 4:30 PM. If you need help to file this form now, call your local police station.
   % endif
   6. Your hearing will probably be over the phone or Zoom video conference.  
-     The address of your court, if you need it, is: ${courts[0].address.on_one_line()}.  
+     The address of your court, if you need it, is: ${trial_court.address.on_one_line()}.  
 
   ${pdf_concatenate(final_attachment_bundle, filename="209a_petition.pdf")} 
 event: download_screen  
@@ -478,7 +471,7 @@ code: |
     allowed_courts = ["Probate and Family Court"]
   else: # not is_dating_only and not (len(children_of_both) and wants_visitation_orders):
     allowed_courts =  ["District Court","Boston Municipal Court", "Probate and Family Court", "Superior Court"]
-  all_matches = macourts.matching_courts(addresses_to_search, court_types=allowed_courts)    
+  all_matches = all_courts.matching_courts(addresses_to_search, court_types=allowed_courts)    
 ---
 if: |
   not len(all_matches)
@@ -491,17 +484,17 @@ reconsider:
   - all_matches
 id: court information (no matching court)
 sets:
-  - courts[0].name
+  - trial_court.name
 question: |
   Where will you file your request?
 subquestion: |
   ${ court_question_template }
 fields:
-  - Choose a court from this list: courts[0]
+  - Choose a court from this list: trial_court
     datatype: object
     object labeler: |
       lambda y: y.short_label()
-    choices: macourts.filter_courts(allowed_courts)
+    choices: all_courts.filter_courts(allowed_courts)
 continue button field: ask_court_question    
 help: |
   ${ court_help_template }
@@ -517,13 +510,13 @@ reconsider:
   - all_matches
 id: court information
 sets:
-  - courts[0].name
+  - trial_court.name
 question: |
   Where will you file your request?
 subquestion: |
   ${ court_question_template }
 fields:
-  - no label: courts[0]
+  - no label: trial_court
     datatype: object_radio
     choices: all_matches
     none of the above: |
@@ -534,13 +527,13 @@ fields:
     show if: 
       code: |
         len(all_matches)      
-  - If your court is not listed above, choose a court from this list: courts[0]
+  - If your court is not listed above, choose a court from this list: trial_court
     datatype: object
     object labeler: |
       lambda y: y.short_label()
-    choices: macourts.filter_courts(allowed_courts)
+    choices: all_courts.filter_courts(allowed_courts)
     show if: 
-      variable: courts[0]
+      variable: trial_court
       is: null    
 continue button field: ask_court_question    
 help: |
@@ -656,7 +649,7 @@ fields:
     validation messages:
       minlength: |
         You cannot continue unless you agree to the terms of use.        
-continue button field: basic_questions_intro_screen
+continue button field: al_intro_screen
 terms:
   green words: |
     Green words are legal terms or a short way of referring to something that needs more explanation. The definition or explanation pops up when you tap the green words.

--- a/docassemble/MA209AProtectiveOrder/data/questions/209a_package.yml
+++ b/docassemble/MA209AProtectiveOrder/data/questions/209a_package.yml
@@ -18,9 +18,6 @@ metadata:
   title: |
     209A Domestic Violence Restraining Order
 ---
-metadata:
-  back button label: Undo
----
 modules:
   - docassemble.ALToolbox.misc
   - docassemble.ALToolbox.ThreePartsDate # Not strictly necessary as long it's installed somewhere on the server

--- a/docassemble/MA209AProtectiveOrder/data/questions/escape.yml
+++ b/docassemble/MA209AProtectiveOrder/data/questions/escape.yml
@@ -4,6 +4,6 @@ comment: |
   Will not be compatible with all browsers. JQuery doesn't offer that kind of support.
 ---
 features:
-  javascript: docassemble.MAVirtualCourt:escape.js
-  css: docassemble.MAVirtualCourt:escape.css
+  javascript: escape.js
+  css: escape.css
 ---

--- a/docassemble/MA209AProtectiveOrder/data/static/escape.css
+++ b/docassemble/MA209AProtectiveOrder/data/static/escape.css
@@ -1,0 +1,27 @@
+/* Escape button for dangerous situations */
+.escape {
+  margin: 0;
+  margin-left: .4em;
+}
+
+@media only screen and (max-width: 30em) {
+  .navbar-brand {
+    margin-right: .3rem;
+  }
+
+  #dapagetitle {
+    margin-right: .4em;
+  }
+
+  #dapagetitle .ma_icon {
+    margin-right: 0;
+  }
+
+  .escape {
+    margin-left: .6em;
+  }
+
+  #dahelptoggle {
+    padding: 0;
+  }
+}

--- a/docassemble/MA209AProtectiveOrder/data/static/escape.js
+++ b/docassemble/MA209AProtectiveOrder/data/static/escape.js
@@ -1,0 +1,18 @@
+/*
+* Inserts quick exit button for sensitive interviews into
+* the page header.
+* 
+* Will not be compatible with all browsers. JQuery doesn't
+* offer that kind of support.
+*/
+
+$(document).on('daPageLoad', function(){
+  let escaper = document.createElement( 'a' );
+  escaper.setAttribute( 'class', 'escape btn btn-danger' );
+  escaper.setAttribute( 'href', 'https://google.com' );
+  escaper.innerHTML = 'Escape';
+
+  // Add to navbar
+  let after = document.getElementById( 'damobile-toggler' );
+  after.parentNode.insertBefore( escaper, after );
+});

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(name='docassemble.MA209AProtectiveOrder',
       url='https://docassemble.org',
       packages=find_packages(),
       namespace_packages=['docassemble'],
-      install_requires=['docassemble.ALToolbox>=0.0.9', 'docassemble.AssemblyLine>=2.0.12', 'docassemble.MassAccess>=0.0.3.1'],
+      install_requires=['docassemble.ALToolbox>=0.0.9.1', 'docassemble.AssemblyLine>=2.0.12', 'docassemble.MassAccess>=0.0.3.1'],
       zip_safe=False,
       package_data=find_package_data(where='docassemble/MA209AProtectiveOrder/', package='docassemble.MA209AProtectiveOrder'),
      )

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(name='docassemble.MA209AProtectiveOrder',
       url='https://docassemble.org',
       packages=find_packages(),
       namespace_packages=['docassemble'],
-      install_requires=['docassemble.ALToolbox>=0.0.9.1', 'docassemble.AssemblyLine>=2.0.12', 'docassemble.MassAccess>=0.0.3.1'],
+      install_requires=['docassemble.ALToolbox>=0.0.9.1', 'docassemble.AssemblyLine>=2.0.15', 'docassemble.MassAccess>=0.0.3.1'],
       zip_safe=False,
       package_data=find_package_data(where='docassemble/MA209AProtectiveOrder/', package='docassemble.MA209AProtectiveOrder'),
      )

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(name='docassemble.MA209AProtectiveOrder',
       url='https://docassemble.org',
       packages=find_packages(),
       namespace_packages=['docassemble'],
-      install_requires=['docassemble.MAVirtualCourt>=1.0.22'],
+      install_requires=['docassemble.ALToolbox>=0.0.9', 'docassemble.AssemblyLine>=2.0.12', 'docassemble.MassAccess>=0.0.3.1'],
       zip_safe=False,
       package_data=find_package_data(where='docassemble/MA209AProtectiveOrder/', package='docassemble.MA209AProtectiveOrder'),
      )

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(name='docassemble.MA209AProtectiveOrder',
       url='https://docassemble.org',
       packages=find_packages(),
       namespace_packages=['docassemble'],
-      install_requires=['docassemble.AssemblyLineToolbox', 'docassemble.MAVirtualCourt>=1.0.20'],
+      install_requires=['docassemble.MAVirtualCourt>=1.0.22'],
       zip_safe=False,
       package_data=find_package_data(where='docassemble/MA209AProtectiveOrder/', package='docassemble.MA209AProtectiveOrder'),
      )


### PR DESCRIPTION
This is part 1 of migration to the AssemblyLine package. Phase 2 will include migration to the ALDocument class

This includes:

1. Changing dependencies from MAVC=>AL. Changing dependency on AssemblyLineToolbox=>ALToolbox. **Note: this makes the 209A package installable on a new server! Important.**
2. Added some functions to ALToolbox that were in the old virtual_court_support.py in MAVC. Therefore, this depends on ALToolbox > 0.9 being installed.
3. Renaming variables, such as courts[0] and basic_questions_intro_screen to the AL equivalent.
4. Renamed objects from VCIndividual to ALIndividual
5. Added gender_fields to ALIndividual class in AssemblyLine repo. Therefore, this depends on AssemblyLine >= 2.0.15 being installed
6. Made use of name_fields and gender_fields method throughout, to reduce strings that need to be translated.
7. Migrated several list collects to one-at-a-time questions for compatibility with name_fields() method.
8. Added escape.js and escape.css directly into this package. It would be reasonable to move this to ALToolbox instead in the future.

I ran through two branches to try to use every new screen.

I did uncover at least one bug in existing 209A, #61 and confirmed it is not related to this code. Overall this is should not change the behavior of the  209A. This should be merged quickly to make the 209A installable on a new server.