### PR TITLE
(only review after #62 has been merged) Addresses #66, affidavit review screen not updating docs

### DIFF
--- a/docassemble/MA209AProtectiveOrder/data/questions/209A-defendant-child-support.yml
+++ b/docassemble/MA209AProtectiveOrder/data/questions/209A-defendant-child-support.yml
@@ -119,6 +119,7 @@ subquestion: |
 attachment code: A_defendant_s_child_support_affidavit_ready_for_upload0004_attachment
 ---
 need: A_defendant_s_child_support_affidavit_ready_for_upload0004
+reconsider: True
 attachment:
     variable name: A_defendant_s_child_support_affidavit_ready_for_upload0004_attachment
     name: Defendant's Affidavit In Connection with Request For Child Support Order
@@ -249,6 +250,7 @@ subquestion: |
   
    ${A_defendant_s_child_support_affidavit_ready_for_upload0004_attachment_preview}
 ---
+reconsider: True
 attachment:
     variable name: A_defendant_s_child_support_affidavit_ready_for_upload0004_attachment_preview
     name: Defendant's Affidavit In Connection with Request For Child Support Order

--- a/docassemble/MA209AProtectiveOrder/data/questions/209A_affidavit.yml
+++ b/docassemble/MA209AProtectiveOrder/data/questions/209A_affidavit.yml
@@ -900,6 +900,7 @@ field: saw_incidents
 code: |
   affidavit_intro = "\n The preceding statement is a brief summary of the events and does not attempt to capture all the detail of the abuse. "
 ---
+reconsider: True
 attachment:
     variable name: complaint_209A_Affidavit_attachment_preview
     name: 209A Complaint Affidavit
@@ -914,6 +915,7 @@ attachment:
       - "incident_date": ${ incident_date }
       - "has_addendum": ${ addAddendum_affidavit }      
 ---
+reconsider: True
 need: complaint_209A_Affidavit
 attachment:
     variable name: complaint_209A_Affidavit_attachment
@@ -934,7 +936,10 @@ code: |
   # E.g., Summer, 2020
   incident_date = most_recent_abuse_date + ", " + str(most_recent_abuse_year)
 ---
-comment: Addenda related code. 
+comment: Addenda related code.
+depends on:
+  - affidavit_body
+  - affidavit_intro
 code: |  
   txtFieldsList_affidavit = list()      
   Limit = 3000

--- a/docassemble/MA209AProtectiveOrder/data/questions/209A_affidavit_disclosing_care_or_custody_proceedings.yml
+++ b/docassemble/MA209AProtectiveOrder/data/questions/209A_affidavit_disclosing_care_or_custody_proceedings.yml
@@ -1001,6 +1001,7 @@ subquestion: |
 attachment code: A_affidavit_disclosing_care_or_custody_proceedings0009_attachment
 ---
 need: need_other_parties_appendix
+reconsider: True
 attachment:
   variable name: care_or_custody_proceedings_appendix_variable
   name: Affidavit Disclosing Care or Custody Proceedings Appendix
@@ -1008,6 +1009,7 @@ attachment:
   docx template file: care_or_custody_proceedings_appendix.docx
 ---
 need: A_affidavit_disclosing_care_or_custody_proceedings0009
+reconsider: True
 attachment:
     variable name: A_affidavit_disclosing_care_or_custody_proceedings0009_attachment
     # skip undefined: True
@@ -1120,6 +1122,7 @@ subquestion: |
 code: |
   need_care_custody_addendum = need_children_appendix or need_other_parties_appendix or need_past_address_appendix or need_attorneys_for_children_addendum or need_attorneys_for_parents_addendum or need_gals_investigators_addendum
 ---
+reconsider: True
 attachment:
     variable name: A_affidavit_disclosing_care_or_custody_proceedings0009_attachment_preview
     name: Affidavit of Care

--- a/docassemble/MA209AProtectiveOrder/data/questions/209A_attach_exhibits.yml
+++ b/docassemble/MA209AProtectiveOrder/data/questions/209A_attach_exhibits.yml
@@ -74,6 +74,7 @@ subquestion: |
   ${exhibits.add_action() }
 continue button field: review_exhibits  
 ---
+reconsider: True
 attachment: 
   docx template file: 209A_exhibit_cover_page.docx
   variable name: exhibit_cover_page

--- a/docassemble/MA209AProtectiveOrder/data/questions/209A_child-support.yml
+++ b/docassemble/MA209AProtectiveOrder/data/questions/209A_child-support.yml
@@ -394,6 +394,7 @@ subquestion: |
   
    ${ Plaintiff_Affidavit_in_support_of_request_for_child_support_order0008_attachment_preview }
 ---
+reconsider: True
 attachment:
     variable name: Plaintiff_Affidavit_in_support_of_request_for_child_support_order0008_attachment_preview
     name: Plaintiff affidavit in support of request for child support order
@@ -483,6 +484,7 @@ subquestion: |
 attachment code: Plaintiff_Affidavit_in_support_of_request_for_child_support_order0008_attachment
 ---
 need: Plaintiff_Affidavit_in_support_of_request_for_child_support_order0008
+reconsider: True
 attachment:
     variable name: Plaintiff_Affidavit_in_support_of_request_for_child_support_order0008_attachment
     name: Plaintiff 209A Child Support Affidavit
@@ -558,6 +560,7 @@ comment: Addenda related code.
 code: |  
   addAddendum_chdSupport = len(all_support_children) > 4
 ---
+reconsider: True
 attachment:
   - variable name: chdSupport_addendum
     docx template file: 209A_chdSupport_addendum.docx

--- a/docassemble/MA209AProtectiveOrder/data/questions/209A_defendant-information.yml
+++ b/docassemble/MA209AProtectiveOrder/data/questions/209A_defendant-information.yml
@@ -364,6 +364,7 @@ subquestion: |
 attachment code: defendantinformation209A0008_attachment
 ---
 need: defendantinformation209A0008
+reconsider: True
 attachment:
     variable name: defendantinformation209A0008_attachment
     # skip undefined: True
@@ -577,6 +578,7 @@ subquestion: |
 #     gun_description_temp.append("a concealed carry license")
 #   gun_description = comma_and_list(gun_description_temp)
 ---
+reconsider: True
 attachment:
     variable name: defendantinformation209A0008_attachment_preview
     # skip undefined: True
@@ -702,6 +704,7 @@ code: |
 
   # addAddendum_defendant = bool(txtFieldsList_defendant) or other_parties[0].photo_yes and other_parties[0].photo_yes_can_upload
 ---
+reconsider: True
 attachment:
   - variable name: defendant_addendum
     docx template file: 209A_defendant_addendum.docx

--- a/docassemble/MA209AProtectiveOrder/data/questions/209A_motion-for-impoundment.yml
+++ b/docassemble/MA209AProtectiveOrder/data/questions/209A_motion-for-impoundment.yml
@@ -138,6 +138,7 @@ subquestion: |
 attachment code: a_258e_motion_for_impoundment0019_attachment
 ---
 need: a_258e_motion_for_impoundment0019
+reconsider: True
 attachment:
     variable name: a_258e_motion_for_impoundment0019_attachment
     name: Motion for Impoundment
@@ -213,6 +214,7 @@ subquestion: |
 
    ${a_258e_motion_for_impoundment0019_attachment_preview}
 ---
+reconsider: True
 attachment:
     variable name: a_258e_motion_for_impoundment0019_attachment_preview
     name: Motion for Impoundment
@@ -266,6 +268,7 @@ code: |
   #addAddendum_impound = bool(txtFieldsList_impoundment)
   addAddendum_impound = False
 ---
+reconsider: True
 attachment:
   - variable name: impound_addendum
     docx template file: 209A_impound_addendum.docx

--- a/docassemble/MA209AProtectiveOrder/data/questions/209A_page_1.yml
+++ b/docassemble/MA209AProtectiveOrder/data/questions/209A_page_1.yml
@@ -1027,6 +1027,7 @@ subquestion: |
   
    ${complaint_209A_labeled_page10003_attachment_preview}
 ---
+reconsider: True
 attachment:
     variable name: complaint_209A_labeled_page10003_attachment_preview
     skip undefined: True
@@ -1103,6 +1104,7 @@ attachment code: complaint_209A_labeled_page10003_attachment
 need: 
   - complaint_209A_labeled_page10003
   - defendant_weapons_safe_for_pdf
+reconsider: True
 attachment:
     variable name: complaint_209A_labeled_page10003_attachment
     skip undefined: True
@@ -1165,6 +1167,7 @@ attachment:
       - "order_relief_ex_parte": ${ order_relief_ex_parte }
       - plaintiff_and_defendant_other_case_description: ${plaintiff_and_defendant_other_case_description if not need_cases_addendum else cases_other_safe_for_pdf}
 ---
+reconsider: True
 attachment:
   - variable name: page1_addendum
     docx template file: 209A_page1_addendum.docx

--- a/docassemble/MA209AProtectiveOrder/data/questions/209A_page_2.yml
+++ b/docassemble/MA209AProtectiveOrder/data/questions/209A_page_2.yml
@@ -803,6 +803,7 @@ subquestion: |
   
   ${A_complaint_for_protection_from_abuse_probation_copy0005_attachment_preview}
 ---
+reconsider: True
 attachment:
     variable name: A_complaint_for_protection_from_abuse_probation_copy0005_attachment_preview
     name: 209A Page 2
@@ -931,6 +932,7 @@ buttons:
 attachment code: A_complaint_for_protection_from_abuse_probation_copy0005_attachment
 ---
 need: A_complaint_for_protection_from_abuse_probation_copy0005
+reconsider: True
 attachment:
     variable name: A_complaint_for_protection_from_abuse_probation_copy0005_attachment
     name: 209A Page 2
@@ -1075,6 +1077,7 @@ code: |
   need_no_contact_addendum = len(children + children_cares_for) and len(wants_no_contact_for) > 6
   addAddendum_page2 = need_custody_addendum or need_no_contact_addendum or bool(txtFieldsList_page2)
 ---
+reconsider: True
 attachment:
   - variable name: page2_addendum
     docx template file: 209A_page2_addendum.docx

--- a/docassemble/MA209AProtectiveOrder/data/questions/209A_plaintiff-confidential.yml
+++ b/docassemble/MA209AProtectiveOrder/data/questions/209A_plaintiff-confidential.yml
@@ -283,6 +283,7 @@ subquestion: |
 attachment code: A_Plaintiff_Confidential_Information0011_attachment
 ---
 need: A_Plaintiff_Confidential_Information0011
+reconsider: True
 attachment:
     variable name: A_Plaintiff_Confidential_Information0011_attachment
     name: Plaintiff Confidential Information Form
@@ -380,6 +381,7 @@ subquestion: |
   
    ${A_Plaintiff_Confidential_Information0011_attachment_preview}
 ---
+reconsider: True
 attachment:
     variable name: A_Plaintiff_Confidential_Information0011_attachment_preview
     name: Plaintiff Confidential Information Form
@@ -458,6 +460,7 @@ code: |
     
   addAddendum_confidential = bool(txtFieldsList_confidential)
 ---
+reconsider: True
 attachment:
   - variable name: confidential_info_addendum
     docx template file: 209A_confidential_info_addendum.docx

--- a/docassemble/MA209AProtectiveOrder/data/questions/209a_package.yml
+++ b/docassemble/MA209AProtectiveOrder/data/questions/209a_package.yml
@@ -671,6 +671,7 @@ code: |
                       }
   final_attachment_collection.finished = True
 ---
+reconsider: True
 attachment: 
   docx template file: 209A_next_steps_for_user.docx
   variable name: next_steps

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(name='docassemble.MA209AProtectiveOrder',
       url='https://docassemble.org',
       packages=find_packages(),
       namespace_packages=['docassemble'],
-      install_requires=['docassemble.ALToolbox>=0.0.9.1', 'docassemble.AssemblyLine>=2.0.15', 'docassemble.MassAccess>=0.0.3.1'],
+      install_requires=['docassemble.ALToolbox>=0.0.10', 'docassemble.AssemblyLine>=2.0.15', 'docassemble.MassAccess>=0.0.3.1'],
       zip_safe=False,
       package_data=find_package_data(where='docassemble/MA209AProtectiveOrder/', package='docassemble.MA209AProtectiveOrder'),
      )


### PR DESCRIPTION
(only review after #62 has been merged)

Addresses #66 recalc values for affidavit. Adds reconsider to all attachments. Does not address all recalculations needed in this document. Maybe we should turn off the ability to edit answers after the documents have been generated until we can address this issue because just using `reconsider: True` on documents did not seem to be sufficient.