### PR TITLE
Advocate improvements with intermediate variable

### DIFF
--- a/docassemble/MA209AProtectiveOrder/data/questions/209A_affidavit.yml
+++ b/docassemble/MA209AProtectiveOrder/data/questions/209A_affidavit.yml
@@ -97,11 +97,22 @@ continue button field: complaint_209A_Affidavit_intro
 question: |
   Your Affidavit
 subquestion: |
+
+  % if plaintiff_assistant_type_obo:
+  
+  Show the judge that ${users.familiar()} needs this restraining order to be safe.
+  
+  In **your own words**, give enough details about the abuse so the judge has a picture in their mind. Your description is your "affidavit."
+  
+  Talk about how the abuse affected ${users.familiar()}. 
+  
+  % else:
+
   Show the judge you need this restraining order to help you be safe.
   
-  "plaintiff_assistant_relationship_to_plaintiff": ${ plaintiff_assistant_relationship_to_plaintiff }
-  
   In your own words, give enough details about the abuse so the judge has a picture in their mind. Your description is your "affidavit."
+  
+  % endif
   
   You should know that if the court does not "{impound}" your affidavit, your words will be public record. It is not easy, but if someone wants to go into court to find and read your affidavit, they can.
   

--- a/docassemble/MA209AProtectiveOrder/data/questions/209A_affidavit.yml
+++ b/docassemble/MA209AProtectiveOrder/data/questions/209A_affidavit.yml
@@ -151,24 +151,29 @@ subquestion: |
   * did something that made you afraid you were about to be seriously physically harmed.
   
   Include information about injuries, medical treatment or dental treatment you needed, destruction of property, or sometimes, the police.
+  
   % endif
+  
   % if plaintiff_assistant_type_obo and plaintiff_has_minor_children:
   * The judge should also know about:
   
-      * Times ${other_parties.familiar()} abused  ${users.familiar()}'s ${children.as_noun()},
-      * Where  ${users.familiar()}'s ${children.as_noun()} ${children.did_verb('was')} when ${other_parties.familiar()} was abusing  ${users.familiar()},
-      * Times ${users.familiar()}'s ${children.as_noun()} witnessed ${other_parties.familiar()} abusing ${users.familiar()}, and
-      * How the abuse affected  ${users.familiar()}'s ${children.as_noun()}.
+      * Times ${other_parties.familiar()} abused  ${users.familiar()}'s ${(children + children_cares_for).as_noun('children')},
+      * Where  ${users.familiar()}'s ${(children + children_cares_for).as_noun('children')} ${(children + children_cares_for).did_verb('was')} when ${other_parties.familiar()} was abusing  ${users.familiar()},
+      * Times ${users.familiar()}'s ${(children + children_cares_for).as_noun('children')} witnessed ${other_parties.familiar()} abusing ${users.familiar()}, and
+      * How the abuse affected  ${users.familiar()}'s ${(children + children_cares_for).as_noun('children')}.
   
   % endif
+  
   % if plaintiff_has_minor_children and not plaintiff_assistant_type_obo:
   * The judge should also know about:
   
-      * Times ${other_parties.familiar()} abused your ${children.as_noun()},
-      * Where your ${children.as_noun()} ${children.did_verb('was')} when ${other_parties.familiar()} was abusing you,
-      * Times your ${children.as_noun()} witnessed ${other_parties.familiar()} abusing you, and
-      * How the abuse affected your ${children.as_noun()}.
+      * Times ${other_parties.familiar()} abused your ${(children + children_cares_for).as_noun('children')},
+      * Where your ${(children + children_cares_for).as_noun('children')} ${(children + children_cares_for).did_verb('was')} when ${other_parties.familiar()} was abusing you,
+      * Times your ${(children + children_cares_for).as_noun('children')} witnessed ${other_parties.familiar()} abusing you, and
+      * How the abuse affected your ${(children + children_cares_for).as_noun('children')}.
+     
   % endif
+  
 ---
 id: 209A Affidavit you can do it
 continue button field: complaint_209A_Affidavit_intro_3
@@ -257,9 +262,9 @@ subquestion: |
 #         incidents_of_abuse[i].description = incidents_of_abuse[i].police_description
 
 #   if plaintiff_has_minor_children:
-#   #  if incidents_of_abuse[i].injuries_self_child:	
-#     incidents_of_abuse[i].injuries_describe	
-#     if incidents_of_abuse[i].injuries_edit:	
+#   #  if incidents_of_abuse[i].injuries_self_child:  
+#     incidents_of_abuse[i].injuries_describe 
+#     if incidents_of_abuse[i].injuries_edit: 
 #       incidents_of_abuse[i].description = incidents_of_abuse[i].injuries_description
 #   else:
 #     if not incidents_of_abuse[i].injuries:
@@ -383,17 +388,17 @@ fields:
     datatype: noyesradio
     help: |
       % if plaintiff_assistant_type_obo:
-      Were any other children, besides ${users.familiar()} harmed? Think about:	
+      Were any other children, besides ${users.familiar()} harmed? Think about: 
       Times ${ other_parties.familiar() } abused ${users.familiar()}'s children. 
-      Where ${users.familiar()}'s ${children.as_noun()} ${children.did_verb('was')} when ${ other_parties.familiar() } was abusing ${users.familiar()}.
+      Where ${users.familiar()}'s ${(children + children_cares_for).as_noun('children')} ${(children + children_cares_for).did_verb('was')} when ${ other_parties.familiar() } was abusing ${users.familiar()}.
       Times ${users.familiar()}'s children witnessed ${ other_parties.familiar() } abusing ${users.familiar()}, and
-      how the abuse affected ${users.familiar()}'s ${children.as_noun()}.
+      how the abuse affected ${users.familiar()}'s ${(children + children_cares_for).as_noun('children')}.
       % else:
-      Were any children harmed? Think about:	
+      Were any children harmed? Think about:  
       Times ${ other_parties.familiar() } abused your children. 
-      Where your ${children.as_noun()} ${children.did_verb('was')} when ${ other_parties.familiar() } was abusing you.
-      Times your ${children.as_noun()} witnessed ${ other_parties.familiar() } abusing you, and
-      how the abuse affected your ${children.as_noun()}.
+      Where your ${(children + children_cares_for).as_noun('children')} ${(children + children_cares_for).did_verb('was')} when ${ other_parties.familiar() } was abusing you.
+      Times your ${(children + children_cares_for).as_noun('children')} witnessed ${ other_parties.familiar() } abusing you, and
+      how the abuse affected your ${(children + children_cares_for).as_noun('children')}.
       % endif
     show if:
       code: |
@@ -466,12 +471,12 @@ question: |
    Were any children harmed?
 subquestion: |
   % if plaintiff_assistant_type_obo:
-  Think about:	
+  Think about:  
   
-   * Times ${ other_parties.familiar() } abused ${ users.familiar() }'s ${children.as_noun()},
-   * Where ${ users.familiar() }'s ${children.as_noun()} ${children.did_verb('was')} e when ${ other_parties.familiar() } was abusing ${ users.familiar() },
-   * Times ${ users.familiar() } ${children.as_noun()} witnessed ${ other_parties.familiar() } abusing ${ users.familiar() }, and
-   * How the abuse affected ${ users.familiar() } ${children.as_noun()}.
+   * Times ${ other_parties.familiar() } abused ${ users.familiar() }'s ${(children + children_cares_for).as_noun('children')},
+   * Where ${ users.familiar() }'s ${(children + children_cares_for).as_noun('children')} ${(children + children_cares_for).did_verb('was')} e when ${ other_parties.familiar() } was abusing ${ users.familiar() },
+   * Times ${ users.familiar() } ${(children + children_cares_for).as_noun('children')} witnessed ${ other_parties.familiar() } abusing ${ users.familiar() }, and
+   * How the abuse affected ${ users.familiar() } ${(children + children_cares_for).as_noun('children')}.
   
   
   **Note:**
@@ -484,14 +489,14 @@ subquestion: |
   
   This is what you have said so far. 
   
-  Edit it as much as you need, to include how this incident affected ${ users.familiar() }'s ${children.as_noun()}.
+  Edit it as much as you need, to include how this incident affected ${ users.familiar() }'s ${(children + children_cares_for).as_noun('children')}.
   % else:
-  Think about:	
+  Think about:  
   
-   * Times ${ other_parties.familiar() } abused your ${children.as_noun()},
-   * Where your ${children.as_noun()} ${children.did_verb('was')} when ${ other_parties.familiar() } was abusing you,
-   * Times your ${children.as_noun()} witnessed ${ other_parties.familiar() } abusing you, and
-   * How the abuse affected your ${children.as_noun()}.
+   * Times ${ other_parties.familiar() } abused your ${(children + children_cares_for).as_noun('children')},
+   * Where your ${(children + children_cares_for).as_noun('children')} ${(children + children_cares_for).did_verb('was')} when ${ other_parties.familiar() } was abusing you,
+   * Times your ${(children + children_cares_for).as_noun('children')} witnessed ${ other_parties.familiar() } abusing you, and
+   * How the abuse affected your ${(children + children_cares_for).as_noun('children')}.
   
   
   **Note:**
@@ -530,21 +535,21 @@ question: |
   Describe any medical treatment
 subquestion: |
   % if plaintiff_assistant_type_obo and plaintiff_has_minor_children:
-   It may help ${ users.familiar() } to tell the judge about any medical or dental treatment ${ users.familiar() } or ${ users.familiar() }'s ${ children.as_noun() } got. 
+   It may help ${ users.familiar() } to tell the judge about any medical or dental treatment ${ users.familiar() } or ${ users.familiar() }'s ${(children + children_cares_for).as_noun('children')} got. 
 
-  Or, if ${ users.familiar()} or ${ users.familiar()}'s ${ children.as_noun() } needed treatment and did not get it, why not? 
+  Or, if ${ users.familiar()} or ${ users.familiar()}'s ${(children + children_cares_for).as_noun('children')} needed treatment and did not get it, why not? 
   
-  This is what you have said so far. Add a description of the medical treatment ${ users.familiar() } or ${ users.familiar() }'s ${ children.as_noun() } needed and the name of the doctor, hospital or clinic that saw ${ users.familiar() } or ${ users.familiar() }'s ${ children.as_noun() }. 
+  This is what you have said so far. Add a description of the medical treatment ${ users.familiar() } or ${ users.familiar() }'s ${(children + children_cares_for).as_noun('children')} needed and the name of the doctor, hospital or clinic that saw ${ users.familiar() } or ${ users.familiar() }'s ${(children + children_cares_for).as_noun('children')}. 
     
-  If there was a reason ${ users.familiar() } or ${ users.familiar() }'s ${ children.as_noun() } could not get medical treatment, you may want to write about that.
+  If there was a reason ${ users.familiar() } or ${ users.familiar() }'s ${(children + children_cares_for).as_noun('children')} could not get medical treatment, you may want to write about that.
   
   % elif plaintiff_has_minor_children and not plaintiff_assistant_type_obo:
-  It may help you to tell the judge about any medical or dental treatment you or your ${ children.as_noun() } got. 
+  It may help you to tell the judge about any medical or dental treatment you or your ${(children + children_cares_for).as_noun('children')} got. 
 
-  Or, if you or your ${ children.as_noun() } needed treatment and did not get it, why not?
-  This is what you have said so far. Add a description of the medical treatment you or your ${ children.as_noun() } needed and the name of the doctor, hospital or clinic that saw you or your ${ children.as_noun() }. 
+  Or, if you or your ${(children + children_cares_for).as_noun('children')} needed treatment and did not get it, why not?
+  This is what you have said so far. Add a description of the medical treatment you or your ${(children + children_cares_for).as_noun('children')} needed and the name of the doctor, hospital or clinic that saw you or your ${(children + children_cares_for).as_noun('children')}. 
     
-  If there was a reason you or your ${ children.as_noun() } could not get medical treatment, you may want to write about that.
+  If there was a reason you or your ${(children + children_cares_for).as_noun('children')} could not get medical treatment, you may want to write about that.
   
   % elif plaintiff_assistant_type_obo and not plaintiff_has_minor_children:
   
@@ -933,14 +938,14 @@ code: |
 # ---
 # id: 209A Affidavit you or child injuries described
 # question: |
-#   Did you include harm to you or your ${children.as_noun()}?
+#   Did you include harm to you or your ${(children + children_cares_for).as_noun('children')}?
 # subquestion: |  
-#   Think about:	
+#   Think about:  
 #   
-#   * Times ${ other_parties.familiar() } abused your ${children.as_noun()},
-#   * Where your ${children.as_noun()} ${children.did_verb('was')} when ${ other_parties.familiar() } was abusing you,
-#   * Times your ${children.as_noun()} witnessed ${ other_parties.familiar() } abusing you, and
-#   * How the abuse affected your ${children.as_noun()}.
+#   * Times ${ other_parties.familiar() } abused your ${(children + children_cares_for).as_noun('children')},
+#   * Where your ${(children + children_cares_for).as_noun('children')} ${(children + children_cares_for).did_verb('was')} when ${ other_parties.familiar() } was abusing you,
+#   * Times your ${(children + children_cares_for).as_noun('children')} witnessed ${ other_parties.familiar() } abusing you, and
+#   * How the abuse affected your ${(children + children_cares_for).as_noun('children')}.
 #   
 #   
 #   **Note:**
@@ -951,7 +956,7 @@ code: |
 #   * Report the abuse to the Department of Children and Families (DCF) who would probably start an investigation, or 
 #   * Do both.
 #   
-#   Did you already describe any injuries that ${ other_parties.familiar() } caused you or your ${children.as_noun()}?
+#   Did you already describe any injuries that ${ other_parties.familiar() } caused you or your ${(children + children_cares_for).as_noun('children')}?
 #   
 #   Injuries do not need to be serious.
 #   
@@ -1050,11 +1055,11 @@ fields:
 #   % if plaintiff_has_minor_children:
 #   You said you have at least 1 child under 18. 
   
-#   Even if ${other_parties.familiar()} did not injure your ${children.as_noun()}, it could be important to include:
+#   Even if ${other_parties.familiar()} did not injure your ${(children + children_cares_for).as_noun('children')}, it could be important to include:
   
 #   * Where your child was during the incident.
-#   * If your ${children.as_noun()} witnessed anything. And
-#   * How it affected your ${children.as_noun()}. 
+#   * If your ${(children + children_cares_for).as_noun('children')} witnessed anything. And
+#   * How it affected your ${(children + children_cares_for).as_noun('children')}. 
 #   % endif
 # yesno: incidents_of_abuse.there_is_another
 ---

--- a/docassemble/MA209AProtectiveOrder/data/questions/209A_affidavit.yml
+++ b/docassemble/MA209AProtectiveOrder/data/questions/209A_affidavit.yml
@@ -126,17 +126,42 @@ terms:
 id: 209 Affidavit what to include
 continue button field: complaint_209A_Affidavit_intro_2
 question: |
-  Explain to the judge why you need a restraining order  
+  % if plaintiff_assistant_type_obo:
+  Explain to the judge why ${users.familiar()} needs a restraining order
+  % else: 
+  Explain to the judge why you need a restraining order
+  % endif
 subquestion: |
+  % if plaintiff_assistant_type_obo:
+  In your affidavit, do your best to describe the times that ${other_parties.familiar()} abused ${users.familiar()}. What did ${other_parties.familiar()} say and do?
+  
+  Write about times that ${other_parties.familiar()}:
+  
+  * abused ${users.familiar()}, or
+  * did something that made ${users.familiar()} afraid that ${other_parties.familiar()} was about to seriously physically harm ${users.familiar()}.
+  
+  Include information about injuries, medical treatment or dental treatment that ${users.familiar()} needed, destruction of property, or sometimes, the police.
+  
+  % else:
   In your affidavit, do your best to describe the times that ${other_parties.familiar()} abused you. What did ${other_parties.familiar()} say and do?
   
   Write about times that ${other_parties.familiar()}:
   
   * abused you, or
   * did something that made you afraid you were about to be seriously physically harmed.
-  Include information about injuries, medical treatment or dental treatment you needed, destruction of property, or sometimes, the police.
-  % if plaintiff_has_minor_children:
   
+  Include information about injuries, medical treatment or dental treatment you needed, destruction of property, or sometimes, the police.
+  % endif
+  % if plaintiff_assistant_type_obo and plaintiff_has_minor_children:
+  * The judge should also know about:
+  
+      * Times ${other_parties.familiar()} abused  ${users.familiar()}'s ${children.as_noun()},
+      * Where  ${users.familiar()}'s ${children.as_noun()} ${children.did_verb('was')} when ${other_parties.familiar()} was abusing  ${users.familiar()},
+      * Times ${users.familiar()}'s ${children.as_noun()} witnessed ${other_parties.familiar()} abusing ${users.familiar()}, and
+      * How the abuse affected  ${users.familiar()}'s ${children.as_noun()}.
+  
+  % endif
+  % if plaintiff_has_minor_children and not plaintiff_assistant_type_obo:
   * The judge should also know about:
   
       * Times ${other_parties.familiar()} abused your ${children.as_noun()},
@@ -148,10 +173,16 @@ subquestion: |
 id: 209A Affidavit you can do it
 continue button field: complaint_209A_Affidavit_intro_3
 question: | 
+  % if plaintiff_assistant_type_obo:
+  ${plaintiff_assistant_name}, you can do this!
+  % else:
   ${users.familiar()}, you can do this!
+  % endif
 subquestion: |
-  Writing your affidavit can be hard for all kinds of reasons. Remember you can always call a domestic violence advocate for help. [Safelink](https://www.casamyrna.org/get-support/safelink): ${tel("1-877-785-2020")}.
-
+  Writing your affidavit can be hard for all kinds of reasons. 
+  % if plaintiff_assistant_type not in('advocate'):
+  Remember you can always call a domestic violence advocate for help. [Safelink](https://www.casamyrna.org/get-support/safelink): ${tel("1-877-785-2020")}.
+  % endif
   Finally, as you write your affidavit, keep in mind that when you sign your name at the end of this guide, you are declaring, “{under penalty of perjury}” that your answers to all these questions are {true to the best of your knowledge}.
 
   1. Start with the most recent abuse first.  
@@ -159,7 +190,16 @@ subquestion: |
 help:
   label: What should I talk about?
   heading: Is this all?
-  content: |
+  content: | 
+    % if plaintiff_assistant_type_obo:
+    Tell the judge about any incidents where  ${users.familiar()} or another child was physically harmed, threatened, felt fear, or tried to get help from police. 
+    
+    Judges often care most about abuse that has happened during the last year.
+    
+    One serious incident can be enough to get an Order for Protection. But adding more incidents may improve  ${users.familiar()}'s chances -- especially if you can show a pattern or trend of abuse. 
+    
+    This is your chance to explain why  ${users.familiar()} needs help.
+    % else:
     Tell the judge about any incidents where you or a child were physically harmed, threatened, felt fear, or tried to get help from police. 
     
     Judges often care most about abuse that has happened during the last year.
@@ -167,6 +207,7 @@ help:
     One serious incident can be enough to get an Order for Protection. But adding more incidents may improve your chances -- especially if you can show a pattern or trend of abuse. 
     
     This is your chance to explain why you need help.
+    % endif
 terms:
   - under penalty of perjury: |
       means you swear that what you write is true, as far as you know.  
@@ -273,8 +314,11 @@ question: |
   Most recent date
   
 subquestion: |
+  % if plaintiff_assistant_type_obo:
+  When was the last time ${other_parties.familiar()} abused ${users.familiar()}?
+  % else:
   When was the last time ${other_parties.familiar()} abused you?  
-
+  % endif
   We need to put the year on the form.
     
   For the date, try to remember the exact date. If you are not sure of the exact date, do not guess.
@@ -338,11 +382,19 @@ fields:
   - children: incidents_of_abuse[i].children
     datatype: noyesradio
     help: |
+      % if plaintiff_assistant_type_obo:
+      Were any other children, besides ${users.familiar()} harmed? Think about:	
+      Times ${ other_parties.familiar() } abused ${users.familiar()}'s children. 
+      Where ${users.familiar()}'s ${children.as_noun()} ${children.did_verb('was')} when ${ other_parties.familiar() } was abusing ${users.familiar()}.
+      Times ${users.familiar()}'s children witnessed ${ other_parties.familiar() } abusing ${users.familiar()}, and
+      how the abuse affected ${users.familiar()}'s ${children.as_noun()}.
+      % else:
       Were any children harmed? Think about:	
       Times ${ other_parties.familiar() } abused your children. 
-      Where your children were when ${ other_parties.familiar() } was abusing you.
-      Times your children witnessed ${ other_parties.familiar() } abusing you, and
-      How the abuse affected your children.
+      Where your ${children.as_noun()} ${children.did_verb('was')} when ${ other_parties.familiar() } was abusing you.
+      Times your ${children.as_noun()} witnessed ${ other_parties.familiar() } abusing you, and
+      how the abuse affected your ${children.as_noun()}.
+      % endif
     show if:
       code: |
         plaintiff_has_minor_children
@@ -385,7 +437,11 @@ fields:
   - cruelty to pets: incidents_of_abuse[i].pets
     datatype: noyesradio
     help: |
+      % if plaintiff_assistant_type_obo:
+      Being cruel to ${users.familiar()}'s pets is a way for ${ other_parties.familiar() } to abuse ${users.familiar()} also. Even threatening to hurt or kill ${users.familiar()}'s pets, as you know, is a way to hurt ${users.familiar()} too.
+      % else:
       Being cruel to your pets is a way for ${ other_parties.familiar() } to abuse you also. Even threatening to hurt or kill your pets, as you know, is a way to hurt you too.
+      % endif
   - Do you need to add anything about your pets?: incidents_of_abuse[i].pets_edit
     datatype: yesnoradio
     show if: incidents_of_abuse[i].pets
@@ -395,7 +451,12 @@ fields:
   - the police being involved: incidents_of_abuse[i].police
     datatype: noyesradio
     help: |
-      You do **not** need to talk about the police. You do not need to have called the police to get a restraining order. If you needed the police and ${ other_parties.familiar() } stopped you from calling them, this information could help the judge understand your situation.
+      You do **not** need to talk about the police. 
+      % if plaintiff_assistant_name:
+      You do not need to have called the police to get a restraining order. And ${users.familiar()} does not need to have called the police. If you or ${users.familiar()} needed the police and ${ other_parties.familiar() } stopped you from calling them, this information could help the judge understand your situation.
+      % else: 
+      You do not need to have called the police to get a restraining order. If you needed the police and ${ other_parties.familiar() } stopped you from calling them, this information could help the judge understand your situation.
+      % endif
   - Do you need to add anything about the police?: incidents_of_abuse[i].police_edit
     datatype: yesnoradio
     show if: incidents_of_abuse[i].police
@@ -404,25 +465,47 @@ id: 209A Affidavit children present
 question: |
    Were any children harmed?
 subquestion: |
- Think about:	
+  % if plaintiff_assistant_type_obo:
+  Think about:	
   
-   * Times ${ other_parties.familiar() } abused your children,
-   * Where your children were when ${ other_parties.familiar() } was abusing you,
-   * Times your children witnessed ${ other_parties.familiar() } abusing you, and
-   * How the abuse affected your children.
+   * Times ${ other_parties.familiar() } abused ${ users.familiar() }'s ${children.as_noun()},
+   * Where ${ users.familiar() }'s ${children.as_noun()} ${children.did_verb('was')} e when ${ other_parties.familiar() } was abusing ${ users.familiar() },
+   * Times ${ users.familiar() } ${children.as_noun()} witnessed ${ other_parties.familiar() } abusing ${ users.familiar() }, and
+   * How the abuse affected ${ users.familiar() } ${children.as_noun()}.
   
   
   **Note:**
   
   If a child has been abused or witnessed abuse, the judge may: 
    
-  * Appoint a Guardian ad Litem to represent your child's interest. 
+  * Appoint a Guardian ad Litem to represent the child's interest. 
+  * Report the abuse to the Department of Children and Families (DCF) who would probably start an investigation, or 
+  * Do both.
+  
+  This is what you have said so far. 
+  
+  Edit it as much as you need, to include how this incident affected ${ users.familiar() }'s ${children.as_noun()}.
+  % else:
+  Think about:	
+  
+   * Times ${ other_parties.familiar() } abused your ${children.as_noun()},
+   * Where your ${children.as_noun()} ${children.did_verb('was')} when ${ other_parties.familiar() } was abusing you,
+   * Times your ${children.as_noun()} witnessed ${ other_parties.familiar() } abusing you, and
+   * How the abuse affected your ${children.as_noun()}.
+  
+  
+  **Note:**
+  
+  If a child has been abused or witnessed abuse, the judge may: 
+   
+  * Appoint a Guardian ad Litem to represent the child's interest. 
   * Report the abuse to the Department of Children and Families (DCF) who would probably start an investigation, or 
   * Do both.
   
   This is what you have said so far. 
   
   Edit it as much as you need, to include how this incident affected your children.
+  % endif
 fields:
   - no label: incidents_of_abuse[i].children_description
     input type: area
@@ -433,7 +516,7 @@ id: 209A Affidavit injuries describe
 question: |
   Describe the harm ${ other_parties.familiar() } caused
 subquestion: |
-  It helps to describe all your injuries in detail, even if the injuries were not serious. Be sure to say who was hurt. 
+  It helps to describe all injuries in detail, even if the injuries were not serious. Be sure to say who was hurt. 
   
   Full sentences are easier for a judge to read and understand. This is what you have said so far:
 fields:
@@ -446,19 +529,44 @@ id: 209A Affidavit Medical treatment describe
 question: |
   Describe any medical treatment
 subquestion: |
-  % if plaintiff_has_minor_children:
-  It may help you to tell the judge about any medical or dental treatment you or your children got. 
+  % if plaintiff_assistant_type_obo and plaintiff_has_minor_children:
+   It may help ${ users.familiar() } to tell the judge about any medical or dental treatment ${ users.familiar() } or ${ users.familiar() }'s ${ children.as_noun() } got. 
 
-  Or, if you or your children needed treatment and did not get it, why not? 
+  Or, if ${ users.familiar()} or ${ users.familiar()}'s ${ children.as_noun() } needed treatment and did not get it, why not? 
+  
+  This is what you have said so far. Add a description of the medical treatment ${ users.familiar() } or ${ users.familiar() }'s ${ children.as_noun() } needed and the name of the doctor, hospital or clinic that saw ${ users.familiar() } or ${ users.familiar() }'s ${ children.as_noun() }. 
+    
+  If there was a reason ${ users.familiar() } or ${ users.familiar() }'s ${ children.as_noun() } could not get medical treatment, you may want to write about that.
+  
+  % elif plaintiff_has_minor_children and not plaintiff_assistant_type_obo:
+  It may help you to tell the judge about any medical or dental treatment you or your ${ children.as_noun() } got. 
+
+  Or, if you or your ${ children.as_noun() } needed treatment and did not get it, why not?
+  This is what you have said so far. Add a description of the medical treatment you or your ${ children.as_noun() } needed and the name of the doctor, hospital or clinic that saw you or your ${ children.as_noun() }. 
+    
+  If there was a reason you or your ${ children.as_noun() } could not get medical treatment, you may want to write about that.
+  
+  % elif plaintiff_assistant_type_obo and not plaintiff_has_minor_children:
+  
+  It may help ${ users.familiar() } to tell the judge about any medical or dental treatment ${ users.familiar() } got. 
+
+  Or, if ${ users.familiar() } needed it and did not get it, why not?
+  
+  This is what you have said so far. Add a description of the medical treatment ${ users.familiar() } needed and the name of the doctor, hospital or clinic that saw ${ users.familiar() }. 
+    
+  If there was a reason ${ users.familiar() } could not get medical treatment, you may want to write about that.
+  
   % else:
   It may help you to tell the judge about any medical or dental treatment you got. 
 
   Or, if you needed it and did not get it, why not? 
-  % endif
-
+  
   This is what you have said so far. Add a description of the medical treatment you needed and the name of the doctor, hospital or clinic that saw you. 
     
-  If there was a reason you could not get medical treatment, you may want to write about that.  
+  If there was a reason you could not get medical treatment, you may want to write about that.
+  % endif
+
+    
 fields: 
   - no label: incidents_of_abuse[i].medical_description
     input type: area
@@ -467,8 +575,21 @@ fields:
 ---
 id: 209A pet cruelty
 question: |
+  % if plaintiff_assistant_type_obo:
+  How did ${other_parties.familiar()} abuse ${ users.familiar() }'s pet?
+  % else:
   How did ${other_parties.familiar()} abuse your pet?
+  % endif
 subquestion: |
+  % if plaintiff_assistant_type_obo:
+  Include  ${ users.familiar() }'s pet's name, whose pet it is, the kind of animal it is and what ${ other_parties.familiar()} did. 
+
+  If ${ other_parties.familiar() } threatened to hurt  ${ users.familiar() }'s pet, write about that. 
+  
+  If ${ other_parties.familiar() } abused more than one pet during this incident, include all the pets involved in your description.
+
+  This is what you have said so far, edit your description to talk about how ${ other_parties.familiar() } was cruel to  ${ users.familiar() }'s pet or pets.
+  % else:
   Include your pet's name, whose pet it is, the kind of animal it is and what ${ other_parties.familiar()} did. 
 
   If ${ other_parties.familiar() } threatened to hurt your pet, write about that. 
@@ -476,6 +597,7 @@ subquestion: |
   If ${ other_parties.familiar() } abused more than one pet during this incident, include all the pets involved in your description.
 
   This is what you have said so far, edit your description to talk about how ${ other_parties.familiar() } was cruel to your pet or pets.
+  % endif
 
 fields: 
   - no label: incidents_of_abuse[i].pets_description
@@ -485,14 +607,22 @@ fields:
 ---
 id: 209A property damage
 question: |
+  % if plaintiff_assistant_type_obo:
+  How did ${other_parties.familiar()} damage any property to hurt ${ users.familiar() }?
+  % else:
   How did ${other_parties.familiar()} damage any property to hurt you?
+  % endif
 subquestion: |    
   Edit what you have said so far to include: 
   
   * what ${ other_parties.familiar()} did or threatened to do,
   * whose property it is, 
-  * the value of the property - emotional, in dollars or both, and 
+  * the value of the property - emotional, in dollars or both, and
+  % if plaintiff_assistant_type_obo:
+  * how ${ users.familiar() } felt about the threat of damage or actual damage.
+  % else:
   * how you felt about the threat of damage or actual damage.
+  % endif
 
 fields: 
   - no label: incidents_of_abuse[i].property_description
@@ -525,15 +655,29 @@ help:
     * did they come in time, 
     * if they arrested anyone, 
     * who they arrested,
-    * if ${ other_parties.familiar() } stopped you from trying to call the police,
+    % if plaintiff_assistant_type_obo:
+    * if ${ other_parties.familiar() } stopped you or ${ users.familiar() } from calling the police,
+    % else:
+    * if ${ other_parties.familiar() } stopped you from calling the police,
+    % endif
     * if the police made a report.
 ---
 id: 209A Affidavit Feelings
 question: |
+  % if plaintiff_assistant_type_obo:
+  Tell the judge how this incident made ${ users.familiar() } feel
+  % else:
   Tell the judge how this incident made you feel
+  % endif
 subquestion: |
-   It gives the judge a better picture if you describe how this incident made you feel. 
-   Write 1 or 2 sentences.
+  % if plaintiff_assistant_type_obo:
+  You cannot say **exactly** how this incident made ${ users.familiar() } feel. But if ${ users.familiar() } shared the incident and feelings with you, or you think ${ users.familiar() } behaves differently now because of the abuse, include your thoughts here.
+  
+  It gives the judge a better picture if you can describe the feelings ${ users.familiar() } told you about or how you think this incident makes ${ users.familiar() } behave differently.  
+  % else:
+  It gives the judge a better picture if you describe how this incident made you feel.
+  % endif
+  Write 1 or 2 sentences.
 fields: 
   - no label: incidents_of_abuse[i].feelings
     input type: area
@@ -558,18 +702,30 @@ fields:
 ---
 id: there is another abuse incident
 question: |
+  % if plaintiff_assistant_type_obo:
+  Can you describe another time ${ other_parties.familiar() } abused ${ users.familiar() }?
+  % else:
   Can you describe another time ${ other_parties.familiar() } abused you?
+  % endif
 yesno: incidents_of_abuse.there_is_another
 ---
 id: pattern of abuse
 question: |
    Can you tell the judge about any "patterns of abuse"? 
 subquestion: |
+  % if plaintiff_assistant_type_obo:
+  Does ${ other_parties.familiar() } do or say anything regularly to: 
+  
+  * scare ${ users.familiar() },
+  * control ${ users.familiar() }, or
+  * stop ${ users.familiar() } from doing things ${ users.familiar() } wants or needs to do?
+  % else:
   Does ${ other_parties.familiar() } do or say anything regularly to: 
   
   * scare you,
   * control you, or
   * stop you from doing things you want or need to do?
+  % endif
 fields:
   - no label: pattern
     datatype: yesnoradio
@@ -581,16 +737,23 @@ help:
   heading: Can you give me some examples?
   content: |
     
-    ### See the Mayo Clinic's webpage:
+    ### See the Mayo Clinic's webpage
     
-    ### [Recognize patterns](https://www.mayoclinic.org/healthy-lifestyle/adult-health/in-depth/domestic-violence/art-20048397?p=1)
+    #### [Recognize patterns](https://www.mayoclinic.org/healthy-lifestyle/adult-health/in-depth/domestic-violence/art-20048397?p=1)
 ---
 id: saw incidents of abuse
 question: |
   This is your Affidavit 
 subquestion: |
-  These are your words. Edit this statement in any way you need so that it says exactly what you need to tell the judge.  
+  These are your words. Edit this statement in any way you need so that it says exactly what you need to tell the judge.
+  
+  % if plaintiff_assistant_type_obo:
+  Once you are satisfied you have told the truth, as far as you know, go on to the next set of questions. 
+  
+  When you continue, **go back to answering the questions as if you were ${ users.familiar() }**.
+  % else:
   Once you are satisfied you have told the truth, as far as you know, go on to the next set of questions.
+  % endif
   
 fields:
   - no label: affidavit_body
@@ -850,17 +1013,18 @@ code: |
 #     input type: area
 #     default: |
 #       ${ incidents_of_abuse[i].description }
----
-id: 209A Affidavit Feelings
-question: |
-  Tell the judge how this incident made you feel
-subquestion: |
-   It gives the judge a better picture if you describe how this incident made you feel. 
-   Write a sentence or 2.
-fields: 
-  - no label: incidents_of_abuse[i].feelings
-    input type: area
-    required: False
+# ---
+# comment: duplicating question from l. 665
+# id: 209A Affidavit Feelings
+# question: |
+#   Tell the judge how this incident made you feel
+# subquestion: |
+#    It gives the judge a better picture if you describe how this incident made you feel. 
+#    Write a sentence or 2.
+# fields: 
+#   - no label: incidents_of_abuse[i].feelings
+#     input type: area
+#     required: False
 ---
 id: 209A Incident Summary
 question: |
@@ -879,9 +1043,9 @@ fields:
     default: |
       ${ incidents_of_abuse[i].description + space("incidents_of_abuse[" + str(i) + "].feelings") }
 ---
-id: there is another abuse incident
-question: |
-  Can you describe another time ${other_parties.familiar()} abused you?
+# id: there is another abuse incident
+# question: |
+#  Can you describe another time ${other_parties.familiar()} abused you?
 # subquestion: |
 #   % if plaintiff_has_minor_children:
 #   You said you have at least 1 child under 18. 
@@ -892,27 +1056,27 @@ question: |
 #   * If your ${children.as_noun()} witnessed anything. And
 #   * How it affected your ${children.as_noun()}. 
 #   % endif
-yesno: incidents_of_abuse.there_is_another
+# yesno: incidents_of_abuse.there_is_another
 ---
-id: saw incidents of abuse
-question: |
-  This is your Affidavit 
-subquestion: |
-  These are your words. Edit this statement in any way you need so that it says exactly what you need to tell the judge.  
-  Once you are satisfied you have told the truth, as far as you know, go on to the next set of questions.
-# The affidavit will start with this text:
-
-# > The following is a brief summary of the events 
-# > and does not attempt to capture all the detail 
-# > of the abuse  
-fields:
-  - no label: affidavit_body
-    input type: area
-    default: |
-      ${  affidavit_summary + pattern_description  }
-    rows: 10
-field: saw_incidents
----
+# id: saw incidents of abuse
+# question: |
+#   This is your Affidavit 
+# subquestion: |
+#   These are your words. Edit this statement in any way you need so that it says exactly what you need to tell the judge.  
+#   Once you are satisfied you have told the truth, as far as you know, go on to the next set of questions.
+# # The affidavit will start with this text:
+# 
+# # > The following is a brief summary of the events 
+# # > and does not attempt to capture all the detail 
+# # > of the abuse  
+# fields:
+#   - no label: affidavit_body
+#     input type: area
+#     default: |
+#       ${  affidavit_summary + pattern_description  }
+#     rows: 10
+# field: saw_incidents
+# ---
 code: |
   affidavit_intro = "\n The preceding statement is a brief summary of the events and does not attempt to capture all the detail of the abuse. "
 ---

--- a/docassemble/MA209AProtectiveOrder/data/questions/209A_page_1.yml
+++ b/docassemble/MA209AProtectiveOrder/data/questions/209A_page_1.yml
@@ -276,6 +276,17 @@ fields:
     js show if: |
       val('advocate_filing_obo') == 'parent' || val('advocate_filing_obo') == 'guardian'      
 ---
+code: |
+  if plaintiff_is_major_yes:
+    plaintiff_assistant_type =''
+    plaintiff_assistant_type_obo = False
+    advocate_filing_obo = ''
+  else:
+   if plaintiff_assistant_type == 'advocate' and advocate_filing_obo in ('parent', 'guardian'):
+     plaintiff_assistant_type_obo = True
+   else:
+     plaintiff_assistant_type_obo = False
+---
 # code: |
 #  if plaintiff_is_major_no:
 #    if not plaintiff_assistant_relationships_to_plaintiff == 'other':
@@ -1071,11 +1082,11 @@ attachment:
       - "defendant_gender_male": ${ other_parties[0].gender_male }
       - "defendant_gender_female": ${ other_parties[0].gender_female }
       - "plaintiff_is_major_yes": ${ plaintiff_is_major_yes }
-      - "plaintiff_is_major_no": ${ plaintiff_is_major_no }
+      - "plaintiff_is_major_no": ${ not plaintiff_is_major_yes }
       - "defendant_and_plaintiff_relationship_married_to_each_other": ${ relationship_to_defendant_married['now'] }
       - "defendant_and_plaintiff_relationship_formerly_married_to_each_other": ${ relationship_to_defendant_married['past'] }
-      - "plaintiff_assistant_name": ${ plaintiff_assistant_name if plaintiff_is_major_no else '' }
-      - "plaintiff_assistant_relationship_to_plaintiff": ${ plaintiff_assistant_relationship_to_plaintiff }
+      - "plaintiff_assistant_name": ${ plaintiff_assistant_name if plaintiff_assistant_type_obo else '' }
+      - "plaintiff_assistant_relationship_to_plaintiff": ${ advocate_filing_obo if plaintiff_assistant_type_obo else plaintiff_assistant_type }
       - "defendant_and_plaintiff_relationship_not_married_but_are_related": ${ defendant_and_plaintiff_relationship_not_married_but_are_related }
       - "defendant_relationship_to_plaintiff_is": ${ defendant_relationship_to_plaintiff_is }
       - "defendant_is_major": ${ defendant_is_major }
@@ -1145,11 +1156,11 @@ attachment:
       - "defendant_gender_male": ${ other_parties[0].gender_male }
       - "defendant_gender_female": ${ other_parties[0].gender_female }
       - "plaintiff_is_major_yes": ${ plaintiff_is_major_yes }
-      - "plaintiff_is_major_no": ${ plaintiff_is_major_no }
+      - "plaintiff_is_major_no": ${ not plaintiff_is_major_no }
       - "defendant_and_plaintiff_relationship_married_to_each_other": ${ relationship_to_defendant_married['now'] }
       - "defendant_and_plaintiff_relationship_formerly_married_to_each_other": ${ relationship_to_defendant_married['past'] }
-      - "plaintiff_assistant_name": ${ plaintiff_assistant_name if plaintiff_is_major_no else '' }
-      - "plaintiff_assistant_relationship_to_plaintiff": ${ plaintiff_assistant_relationship_to_plaintiff }
+      - "plaintiff_assistant_name": ${ plaintiff_assistant_name if plaintiff_assistant_type_obo else '' }
+      - "plaintiff_assistant_relationship_to_plaintiff": ${ advocate_filing_obo if plaintiff_assistant_type_obo else plaintiff_assistant_type }
       - "defendant_and_plaintiff_relationship_not_married_but_are_related": ${ defendant_and_plaintiff_relationship_not_married_but_are_related }
       - "defendant_relationship_to_plaintiff_is": ${ defendant_relationship_to_plaintiff_is }
       - "defendant_is_major": ${ defendant_is_major }

--- a/docassemble/MA209AProtectiveOrder/data/questions/209A_plaintiff-confidential.yml
+++ b/docassemble/MA209AProtectiveOrder/data/questions/209A_plaintiff-confidential.yml
@@ -241,10 +241,14 @@ id: contact information
 question: |
   Contact information
 subquestion: |
-  Put at least one way for the court to reach you below.
+  % if plaintiff_assistant_type_obo: 
+  ${ plaintiff_assistant_name }, since you are filing **for** ${ users.familiar() }, enter the best way for the court to contact information **you**. 
+  % endif
+  Give the court least one way to reach you.
 
-  You will have a chance to request this contact information
-  to be kept private later.
+  Later, you will get a chance to ask the court to keep this contact information
+  private.
+  
 fields:
   - Mobile number: users[0].mobile_number
     maxlength: 14
@@ -328,14 +332,22 @@ comment: |
   This question is used to introduce your interview. Please customize
 continue button field: A_Plaintiff_Confidential_Information0011_intro # SMEs to provide splash page language.
 question: |
+  % if plaintiff_assistant_type in ('parent', 'guardian') or plaintiff_assistant_type_obo:
+  Keeping information about you safe
+  % else:
   Getting and staying in touch with you
+  % endif
 subquestion: |
   The next questions ask for your home, work, school, email address and phone numbers. 
   
-  The court needs this information to:
   
+  % if plaintiff_assistant_type in ('parent', 'guardian') or plaintiff_assistant_type_obo:
+  The court needs this information to make an order that will help keep you as safe as possible.
+  % else:
+  The court needs this information to:
   * contact you about your case, and
   * make an order that will help keep you as safe as possible.
+  % endif
   
   ${other_parties.familiar()}, ${other_parties.familiar()}’s lawyer, and the public are not allowed to see this information about you.
   

--- a/docassemble/MA209AProtectiveOrder/data/questions/209a_package.yml
+++ b/docassemble/MA209AProtectiveOrder/data/questions/209a_package.yml
@@ -61,32 +61,33 @@ code: |
   nav.set_section('section_basic')  
   who_protecting_screener # We don't use this yet?  
   users[0].name.first
+  plaintiff_assistant_type_obo
   # if who_protecting_screener == "someone else":
   #  plaintiff_assistant_relationship_to_plaintiff
   # plaintiff_is_major_yes # Ask for age
-  if plaintiff_is_major_yes: # Plaintiff over 18
-    plaintiff_is_major_no = False
-    # plaintiff_assistant_name = DAEmpty()
-    plaintiff_assistant_type = DAEmpty()   
-  else: # if not over 18
-    plaintiff_is_major_no = True
-    # place holder until plaintiff_assistant_relationship_to_plaintiff is removed
-    plaintiff_assistant_relationship_to_plaintiff = plaintiff_assistant_type
-    if who_protecting_screener == 'someone else':
-      if plaintiff_assistant_type == 'advocate':
-        advocate_filing_obo
-      elif plaintiff_assistant_type not in ('parent', 'guardian'):
-        refer_to_advocate
-      else:
-        dcf_warning_given
-    else: # not protecting someone else
-      if plaintiff_assistant_type == 'self':
-        refer_to_advocate
-      else:
-        plaintiff_assistant_relationship_to_plaintiff = plaintiff_assistant_type
-        plaintiff_assistant_type_name
-        plaintiff_assistant_name
-        dcf_warning_given
+  #if plaintiff_is_major_yes: # Plaintiff over 18
+  #  plaintiff_is_major_no = False
+  #  # plaintiff_assistant_name = DAEmpty()
+  #  plaintiff_assistant_type = DAEmpty()   
+  #else: # if not over 18
+  #  plaintiff_is_major_no = True
+  #  # place holder until plaintiff_assistant_relationship_to_plaintiff is removed
+  #  # plaintiff_assistant_relationship_to_plaintiff = plaintiff_assistant_type
+  #  if who_protecting_screener == 'someone else':
+  #    if plaintiff_assistant_type == 'advocate':
+  #      advocate_filing_obo
+  if plaintiff_assistant_type in('self', 'other'):
+    refer_to_advocate
+  elif plaintiff_assistant_type in('parent', 'guardian', 'advocate'):
+    dcf_warning_given
+  #  else: # not protecting someone else
+  #    if plaintiff_assistant_type == 'self':
+  #      refer_to_advocate
+  #    else:
+  #      # plaintiff_assistant_relationship_to_plaintiff = plaintiff_assistant_type
+  #      plaintiff_assistant_type_name
+  #      plaintiff_assistant_name
+  #      dcf_warning_given
 
   if who_protecting_screener == 'someone else':
     tell_user_about_first_person_questions   
@@ -247,11 +248,23 @@ fields:
 ---
 id: explain first person questions
 question: |
+  % if plaintiff_assistant_type_obo:   
+  You are helping ${plaintiff_assistant_name} fill out this form for ${users.familiar()}
+  % else:
   You are helping ${users.familiar()} fill out this form
+  % endif
 subquestion: |
+  % if plaintiff_assistant_type_obo:
+  Answer the rest of the questions as if you are ${users.familiar()}.
+  
+  **Except for the questions about the affidavit.**
+  
+  The affidavit should be in ${plaintiff_assistant_name}'s words. 
+  % else:
   Answer the rest of the questions as if you are ${users.familiar()}. 
   
   Some answers need to be in ${users.familiar()}'s own words.
+  % endif
 field: tell_user_about_first_person_questions  
 ---
 id: preview form

--- a/docassemble/MA209AProtectiveOrder/data/questions/209a_package.yml
+++ b/docassemble/MA209AProtectiveOrder/data/questions/209a_package.yml
@@ -249,9 +249,9 @@ fields:
 id: explain first person questions
 question: |
   % if plaintiff_assistant_type_obo:   
-  You are helping ${plaintiff_assistant_name} fill out this form for ${users.familiar()}
+  Because you are helping ${plaintiff_assistant_name} fill out this form for ${users.familiar()}
   % else:
-  You are helping ${users.familiar()} fill out this form
+  Because you are helping ${users.familiar()} fill out this form
   % endif
 subquestion: |
   % if plaintiff_assistant_type_obo:


### PR DESCRIPTION
Improving the Advocate Improvements incrementally:

- added the new intermediate variable to account for advocate filing obo parent or guardian
- changed the language in the Affidavit questions
- fixed issue #67 child children ${children.did_verb('was')} not conjugating correctly if minor plaintiff is responsible for minor children with @plocket's help.
- still need to fix plaintiff confidential information form to reflect if parent or guardian filing or  advocate filing obo parent or guardian 