### PR TITLE
Fix production issues with 209A

### DIFF
--- a/docassemble/MA209AProtectiveOrder/data/questions/209a_package.yml
+++ b/docassemble/MA209AProtectiveOrder/data/questions/209a_package.yml
@@ -580,7 +580,10 @@ objects:
 attachment: 
   docx template file: 209A_next_steps_for_user.docx
   variable name: next_steps[i]
-
+---
+generic object: ALDocument
+code: |
+  x.overflow_message = " [See addendum]"
 ---
 objects:
   - al_user_bundle: ALDocumentBundle.using(elements=[

--- a/docassemble/MA209AProtectiveOrder/data/questions/209a_package.yml
+++ b/docassemble/MA209AProtectiveOrder/data/questions/209a_package.yml
@@ -16,8 +16,18 @@ include:
  - 209A_motion-for-impoundment.yml
  - 209A_review.yml
  - 209A_plaintiff-confidential.yml 
- - escape.yml
- - 209A_attach_exhibits.yml 
+ - docassemble.ALToolbox:escape_button.yml
+ - 209A_attach_exhibits.yml
+---
+code: |
+  al_interview_languages = ["en", "es"]
+---
+default screen parts:
+  navigation bar html: |
+    % for nav_item in al_navigation_items.values():
+    ${ nav_item }
+    % endfor
+    ${ get_language_list_dropdown(al_interview_languages,current=al_user_language ) } 
 ---
 metadata:
   title: |
@@ -527,12 +537,12 @@ fields:
     datatype: date
     default: ${today().format("yyyy-MM-dd")}
 ---
-comment: |
-  TODO: integrate a method to display form title on intro screen dynamically
 id: basic questions intro screen
 question: |
   Ask the court for a 209A Abuse Prevention Order: MassAccess Project
 subquestion: |
+  ${ get_language_list(current=al_user_language, lang_codes=al_interview_languages) }
+
   This website can help you complete and download your forms in 3 steps:
   
   Step 1. Answer questions that will fill in your forms for you.  
@@ -575,7 +585,7 @@ objects:
   - next_steps: ALDocument.using(title="Next Steps",
                                  filename="next_steps",
                                  has_addendum=False,
-                                 enabled=True)  
+                                 enabled=True)
 ---
 attachment: 
   docx template file: 209A_next_steps_for_user.docx

--- a/docassemble/MA209AProtectiveOrder/data/questions/translation_support.yml
+++ b/docassemble/MA209AProtectiveOrder/data/questions/translation_support.yml
@@ -1,36 +1,6 @@
 ---
-modules:
-  - docassemble.AssemblyLine.language
----
-initial: True
-code: |
-  process_action()
----
-initial: True
-code: |
-  set_language(user_language)
----
-code: |
-  if url_args.get('lang'):
-    user_language = url_args.get('lang')
-  else:
-    user_language= 'en'
----
-event: change_language
-code: |
-  if 'lang' in action_arguments():
-    user_language = action_argument('lang')
-    set_language(user_language)
----
-#comment: |
-#    % if get_config('debug'):
-#    `id: ${ user_info().question_id }`  
-#    `Package: ${ user_info().package } ${ package_version_number }; ${ al_version }`
-#    <div data-variable="${ encode_name(str( user_info().variable )) }" id="sought_variable" aria-hidden="true" style="display: none;"></div>
-#    % endif  
-default screen parts:
-  pre: |    
-    ${get_language_list(get_tuples(['en','es']),current=user_language)}
+include:
+  - docassemble.AssemblyLine:al_language.yml
 ---
 language: es
 sections:


### PR DESCRIPTION
Fix #99 

This was a whole rabbit hole.

* language.py use was broken, switch to new method of invoking language functions (also depends on newest AL which isn't version tagged yet)
* Switch to ALToolbox escape button method because the new language code doesn't work with the old custom JS method of doing the escape button